### PR TITLE
Added option -B to maven to disables output color

### DIFF
--- a/src/MooseNexus/NexusMavenProject.class.st
+++ b/src/MooseNexus/NexusMavenProject.class.st
@@ -115,7 +115,7 @@ NexusMavenProject >> read [
 	"Runs the `mvn` command using the `dependency:resolve` plugin.
 	Requires Maven to be installed."
 
-	^ LibC resultOfCommand: 'cd ' , directory , ' && mvn dependency:resolve'
+	^ LibC resultOfCommand: 'cd ' , directory , ' && mvn -B dependency:resolve'
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
On linux output is colored in the terminal.
This breaks the parsing of the result