### PR TITLE
Make recorded project coordinates immutable

### DIFF
--- a/.project
+++ b/.project
@@ -1,4 +1,6 @@
 {
 	'srcDirectory' : 'src',
-	'tags' : [ #Moose ]
+	'tags' : [
+		#Moose
+	]
 }

--- a/README.md
+++ b/README.md
@@ -39,16 +39,17 @@ project := NexusRepository default
 ```
 
 This will attempt to find project properties automatically: group, version, and language.
-If more control over properties is required, set them before the project is added to the repository:
+If more control over coordinates is required, provide them before the project is added to the repository:
 
 ```st
 sourcePath := 'path/to/sources'.
-project := NexusProjectImporter importFromDirectory: sourcePath.
-project name: 'name'.
-project group: 'group'.
-project version: 'version'.
-project language: 'language'. "in lower case"
-NexusRepository default recordProject: project fromDirectory: sourcePath.
+coordinates := NexusProjectCoordinates
+	group: 'group'
+	name: 'name'
+	version: 'version'.
+project := NexusRepository default
+	importCoordinates: coordinates
+	fromDirectory: sourcePath.
 ```
 
 Retrieve an existing project from a Nexus repository:

--- a/src/BaselineOfMooseNexus/BaselineOfMooseNexus.class.st
+++ b/src/BaselineOfMooseNexus/BaselineOfMooseNexus.class.st
@@ -10,15 +10,13 @@ BaselineOfMooseNexus >> baseline: spec [
 
 	<baseline>
 	spec for: #common do: [
-		spec
-			package: 'MooseNexus'
-			with: [ spec requires: #( 'MooseNexus-UI' ) ];
-			package: 'MooseNexus-UI';
-			package: 'MooseNexus-Tests'
-			with: [ spec requires: #( 'MooseNexus' ) ].
+			spec
+				package: 'MooseNexus' with: [ spec requires: #( 'MooseNexus-UI' ) ];
+				package: 'MooseNexus-UI';
+				package: 'MooseNexus-Tests' with: [ spec requires: #( 'MooseNexus' ) ].
 
-		spec
-			group: 'core' with: #( 'MooseNexus' );
-			group: 'tests' with: #( 'MooseNexus-Tests' );
-			group: 'default' with: #( core tests ) ]
+			spec
+				group: 'core' with: #( 'MooseNexus' );
+				group: 'tests' with: #( 'MooseNexus-Tests' );
+				group: 'default' with: #( core tests ) ]
 ]

--- a/src/MooseNexus-Tests/NexusFirstFoundDependencyConflictResolverTest.class.st
+++ b/src/MooseNexus-Tests/NexusFirstFoundDependencyConflictResolverTest.class.st
@@ -23,18 +23,14 @@ NexusFirstFoundDependencyConflictResolverTest >> testResolveConflictsOn [
 		             with: 'org:example' -> {
 				             (Dictionary with: #version -> 'awfulVersion').
 				             (Dictionary with: #version -> 'awesomeVersion').
-				             (Dictionary with: #version -> 'worstVersion') }
-				             asOrderedCollection
+				             (Dictionary with: #version -> 'worstVersion') } asOrderedCollection
 		             with: 'com:potato' -> {
 				             (Dictionary with: #version -> '2b.39.451e-rc').
-				             (Dictionary with: #version -> '2a.39.451e-rc') }
-				             asOrderedCollection.
+				             (Dictionary with: #version -> '2a.39.451e-rc') } asOrderedCollection.
 
 	resolver resolveConflicts: conflicts on: (resolved := Dictionary new).
 
 	self assert: resolved equals: (Dictionary
-			 with:
-			 'org:example' -> (Dictionary with: #version -> 'awfulVersion')
-			 with:
-			 'com:potato' -> (Dictionary with: #version -> '2b.39.451e-rc'))
+			 with: 'org:example' -> (Dictionary with: #version -> 'awfulVersion')
+			 with: 'com:potato' -> (Dictionary with: #version -> '2b.39.451e-rc'))
 ]

--- a/src/MooseNexus-Tests/NexusMavenProjectParameterizedTest.class.st
+++ b/src/MooseNexus-Tests/NexusMavenProjectParameterizedTest.class.st
@@ -38,9 +38,8 @@ NexusMavenProjectParameterizedTest class >> case1 [
 [INFO]'.
 
 	projects := Dictionary with:
-		            group -> (Dictionary with: projectName -> (Dictionary
-				              with: #version -> version
-				              with: #dependencies -> Dictionary new)).
+		            group
+		            -> (Dictionary with: projectName -> (Dictionary with: #version -> version with: #dependencies -> Dictionary new)).
 
 	^ self
 		  initializeCase: {
@@ -102,11 +101,8 @@ NexusMavenProjectParameterizedTest class >> case2 [
 			                 with: #scope -> 'provided') }.
 
 	"expected projects to parse"
-	(projects := Dictionary new)
-		at: group
-		put: (Dictionary with: projectName -> (Dictionary
-					  with: #version -> version
-					  with: #dependencies -> (projectDependencies := Dictionary new))).
+	(projects := Dictionary new) at: group put: (Dictionary with:
+			 projectName -> (Dictionary with: #version -> version with: #dependencies -> (projectDependencies := Dictionary new))).
 	projectDependencies
 		at: 'org.moose' put: {
 				(Dictionary
@@ -152,46 +148,34 @@ NexusMavenProjectParameterizedTest class >> initializeCase: aCase withMavenOutpu
 	root := 'pharo-local/nexus/tests' asFileReference.
 
 	"initialize mock Maven repository"
-	repositoryPath := (root / 'mavenRepository') ensureCreateDirectory
-		                  absolutePath pathString.
+	repositoryPath := (root / 'mavenRepository') ensureCreateDirectory absolutePath pathString.
 	dependencies do: [ :dependency |
-		| depName depVersion depPath |
-		depName := dependency at: #name.
-		depVersion := dependency at: #version.
-		depPath := String streamContents: [ :s |
-			           s << repositoryPath << '/'
-			           <<
-			           ((dependency at: #group) copyReplaceAll: '.' with: '/')
-			           << '/' << depName << '/' << depVersion << '/' << depName
-			           << '-' << depVersion << '.' << (dependency at: #type) ].
-		"create mock artifact and set the expected path of the artifact"
-		depPath := (depPath asFileReference ensureCreateFile relativeTo:
-			            FileLocator home) pathString.
-		dependency at: #path put: depPath ].
+			| depName depVersion depPath |
+			depName := dependency at: #name.
+			depVersion := dependency at: #version.
+			depPath := String streamContents: [ :s |
+					           s << repositoryPath << '/' << ((dependency at: #group) copyReplaceAll: '.' with: '/') << '/' << depName << '/'
+					           << depVersion << '/' << depName << '-' << depVersion << '.' << (dependency at: #type) ].
+			"create mock artifact and set the expected path of the artifact"
+			depPath := (depPath asFileReference ensureCreateFile relativeTo: FileLocator home) pathString.
+			dependency at: #path put: depPath ].
 
 	"compute paths of projects and dependencies"
 	projects do: [ :projectGroup |
-		projectGroup do: [ :subProject |
-			subProject at: #path put: '.'.
-			(subProject at: #dependencies) keysAndValuesDo: [
-				:groupName
-				:dependencyGroup |
-				dependencyGroup do: [ :dependency | "'dependency at: #path' is the repository name only, compute the rest of the path"
-					| depName depVersion filename path |
-					depName := dependency at: #name.
-					depVersion := dependency at: #version.
-					filename := String streamContents: [ :s |
-						            s << depName << '-' << depVersion << '.jar' ].
-					path := ((root / (dependency at: #path)
-					          / (groupName copyReplaceAll: '.' with: '/') / depName
-					          / depVersion / filename) absolutePath relativeTo:
-						         FileLocator home) pathString.
-					dependency at: #path put: path ] ] ] ].
+			projectGroup do: [ :subProject |
+					subProject at: #path put: '.'.
+					(subProject at: #dependencies) keysAndValuesDo: [ :groupName :dependencyGroup |
+							dependencyGroup do: [ :dependency | "'dependency at: #path' is the repository name only, compute the rest of the path"
+									| depName depVersion filename path |
+									depName := dependency at: #name.
+									depVersion := dependency at: #version.
+									filename := String streamContents: [ :s | s << depName << '-' << depVersion << '.jar' ].
+									path := ((root / (dependency at: #path) / (groupName copyReplaceAll: '.' with: '/') / depName / depVersion / filename)
+										         absolutePath relativeTo: FileLocator home) pathString.
+									dependency at: #path put: path ] ] ] ].
 
 	"create the project subdirectories, mostly used to determine the language"
-	directories do: [ :path |
-		(root / projectName / 'sources/project' / path)
-			ensureCreateDirectory ].
+	directories do: [ :path | (root / projectName / 'sources/project' / path) ensureCreateDirectory ].
 
 	"initialize the NexusProject and its importer"
 	project := aCase at: #project put: NexusMavenProject new.
@@ -200,8 +184,7 @@ NexusMavenProjectParameterizedTest class >> initializeCase: aCase withMavenOutpu
 	importer := NexusMavenProjectImporter new.
 	importer project: project.
 	importer directory: project directory.
-	importer localRepositories: { (NexusMavenRepository new directory:
-			 (root / 'mavenRepository') pathString) }.
+	importer localRepositories: { (NexusMavenRepository new directory: (root / 'mavenRepository') pathString) }.
 
 	importer parse: mavenOutput.
 	project dependencies: importer flatDependencies.
@@ -281,9 +264,7 @@ NexusMavenProjectParameterizedTest >> testDetermineVersion [
 { #category : 'tests' }
 NexusMavenProjectParameterizedTest >> testFlattenDependencies [
 
-	self
-		assertCollection: project dependencies
-		hasSameElements: dependencies
+	self assertCollection: project dependencies hasSameElements: dependencies
 ]
 
 { #category : 'tests' }

--- a/src/MooseNexus-Tests/NexusProjectIdentityTest.class.st
+++ b/src/MooseNexus-Tests/NexusProjectIdentityTest.class.st
@@ -14,20 +14,17 @@ Class {
 NexusProjectIdentityTest >> setUp [
 
 	super setUp.
-	rootDirectory := FileLocator temp
-	                 / ('MooseNexus-' , UUID new asString).
+	rootDirectory := FileLocator temp / ('MooseNexus-' , UUID new asString).
 	sourceDirectory := rootDirectory / 'source'.
 	sourceDirectory ensureCreateDirectory.
-	sourceDirectory / 'README.txt' writeStreamDo: [ :stream |
-		stream nextPutAll: 'test source project' ].
+	sourceDirectory / 'README.txt' writeStreamDo: [ :stream | stream nextPutAll: 'test source project' ].
 	repository := NexusRepository new directory: rootDirectory / 'nexus'
 ]
 
 { #category : 'running' }
 NexusProjectIdentityTest >> tearDown [
 
-	rootDirectory ifNotNil: [
-		rootDirectory ifExists: [ rootDirectory deleteAll ] ].
+	rootDirectory ifNotNil: [ rootDirectory ifExists: [ rootDirectory deleteAll ] ].
 	super tearDown
 ]
 

--- a/src/MooseNexus-Tests/NexusProjectIdentityTest.class.st
+++ b/src/MooseNexus-Tests/NexusProjectIdentityTest.class.st
@@ -1,0 +1,89 @@
+Class {
+	#name : 'NexusProjectIdentityTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'repository',
+		'sourceDirectory',
+		'rootDirectory'
+	],
+	#category : 'MooseNexus-Tests',
+	#package : 'MooseNexus-Tests'
+}
+
+{ #category : 'running' }
+NexusProjectIdentityTest >> setUp [
+
+	super setUp.
+	rootDirectory := FileLocator temp
+	                 / ('MooseNexus-' , UUID new asString).
+	sourceDirectory := rootDirectory / 'source'.
+	sourceDirectory ensureCreateDirectory.
+	sourceDirectory / 'README.txt' writeStreamDo: [ :stream |
+		stream nextPutAll: 'test source project' ].
+	repository := NexusRepository new directory: rootDirectory / 'nexus'
+]
+
+{ #category : 'running' }
+NexusProjectIdentityTest >> tearDown [
+
+	rootDirectory ifNotNil: [
+		rootDirectory ifExists: [ rootDirectory deleteAll ] ].
+	super tearDown
+]
+
+{ #category : 'tests' }
+NexusProjectIdentityTest >> testCoordinatesCanChangeBeforeRecording [
+
+	| project coordinates |
+	project := NexusTestProject new.
+	coordinates := NexusProjectCoordinates group: 'com.example' name: 'demo' version: '1.0.0'.
+	project coordinates: coordinates.
+
+	self assert: project coordinates equals: coordinates.
+	self assert: project group equals: 'com.example'.
+	self assert: project name equals: 'demo'.
+	self assert: project version equals: '1.0.0'
+]
+
+{ #category : 'tests' }
+NexusProjectIdentityTest >> testProjectCoordinatesAreValueObjects [
+
+	| coordinates sameCoordinates otherCoordinates |
+	coordinates := NexusProjectCoordinates group: 'com.example' name: 'demo' version: '1.0.0'.
+	sameCoordinates := NexusProjectCoordinates group: 'com.example' name: 'demo' version: '1.0.0'.
+	otherCoordinates := NexusProjectCoordinates group: 'com.example' name: 'demo' version: '2.0.0'.
+
+	self assert: coordinates equals: sameCoordinates.
+	self deny: coordinates equals: otherCoordinates.
+	self assert: coordinates printString equals: 'com.example:demo:1.0.0'
+]
+
+{ #category : 'tests' }
+NexusProjectIdentityTest >> testRecordedProjectRejectsCoordinateChanges [
+
+	| project coordinates |
+	coordinates := NexusProjectCoordinates group: 'com.example' name: 'demo' version: '1.0.0'.
+	project := NexusTestProject new.
+	project
+		coordinates: coordinates;
+		directory: 'nexus/repository/com.example/demo/1.0.0'.
+
+	self should: [ project coordinates: (NexusProjectCoordinates group: 'org.example' name: 'demo' version: '1.0.0') ] raise: Error.
+	self should: [ project group: 'org.example' ] raise: Error.
+	self should: [ project name: 'renamed' ] raise: Error.
+	self should: [ project version: '2.0.0' ] raise: Error
+]
+
+{ #category : 'tests' }
+NexusProjectIdentityTest >> testRepositoryRecordWithCoordinatesSetsIdentityBeforeRecording [
+
+	| project coordinates recordedProject |
+	project := NexusTestProject new.
+	coordinates := NexusProjectCoordinates group: 'com.example' name: 'demo' version: '1.0.0'.
+	recordedProject := repository recordProject: project coordinates: coordinates fromDirectory: sourceDirectory pathString.
+
+	self assert: recordedProject identicalTo: project.
+	self assert: project coordinates equals: coordinates.
+	self assert: project isRecorded.
+	self assert: (repository directory / 'repository' / 'com.example' / 'demo' / '1.0.0' / 'properties.json') exists
+]

--- a/src/MooseNexus-Tests/NexusSemanticVersioningDependencyConflictResolverTest.class.st
+++ b/src/MooseNexus-Tests/NexusSemanticVersioningDependencyConflictResolverTest.class.st
@@ -26,11 +26,9 @@ NexusSemanticVersioningDependencyConflictResolverTest >> testCheckAndSortByVersi
 		               (Dictionary with: #version -> '1.0.0').
 		               (Dictionary with: #version -> '1.0.1').
 		               (Dictionary with: #version -> '1.1.0').
-		               (Dictionary with: #version -> '1.1.1') }
-		               asOrderedCollection.
+		               (Dictionary with: #version -> '1.1.1') } asOrderedCollection.
 
-	sorted := (resolver checkAndSortByVersion: descriptors reversed)
-		          collect: #value.
+	sorted := (resolver checkAndSortByVersion: descriptors reversed) collect: #value.
 
 	self assert: sorted equals: descriptors
 ]
@@ -45,15 +43,11 @@ NexusSemanticVersioningDependencyConflictResolverTest >> testCheckAndSortByVersi
 		               (Dictionary with: #version -> '9.5.1').
 		               (Dictionary with: #version -> '9.5.1-rc').
 		               (Dictionary with: #version -> '9.5').
-		               (Dictionary with: #version -> '12e') }
-		               asOrderedCollection.
+		               (Dictionary with: #version -> '12e') } asOrderedCollection.
 
-	sorted := (resolver checkAndSortByVersion: descriptors) collect: [
-		          :descriptor | descriptor value at: #version ].
+	sorted := (resolver checkAndSortByVersion: descriptors) collect: [ :descriptor | descriptor value at: #version ].
 
-	self
-		assert: sorted
-		equals: { '9.5'. '9.5.1'. '12e'. '12.3.0' } asOrderedCollection
+	self assert: sorted equals: { '9.5'. '9.5.1'. '12e'. '12.3.0' } asOrderedCollection
 ]
 
 { #category : 'tests' }
@@ -64,12 +58,9 @@ NexusSemanticVersioningDependencyConflictResolverTest >> testCheckAndSortByVersi
 	descriptors := {
 		               (Dictionary with: #version -> '1.0').
 		               (Dictionary with: #version -> '1.0-alpha').
-		               (Dictionary with: #version -> '1.0-rc') }
-		               asOrderedCollection.
+		               (Dictionary with: #version -> '1.0-rc') } asOrderedCollection.
 
-	self
-		assert: (resolver checkAndSortByVersion: descriptors)
-		equals: nil
+	self assert: (resolver checkAndSortByVersion: descriptors) equals: nil
 ]
 
 { #category : 'tests' }
@@ -80,12 +71,9 @@ NexusSemanticVersioningDependencyConflictResolverTest >> testCheckAndSortByVersi
 	descriptors := {
 		               (Dictionary with: #version -> 'alpha').
 		               (Dictionary with: #version -> 'beta').
-		               (Dictionary with: #version -> 'rc') }
-		               asOrderedCollection.
+		               (Dictionary with: #version -> 'rc') } asOrderedCollection.
 
-	self
-		assert: (resolver checkAndSortByVersion: descriptors)
-		equals: nil
+	self assert: (resolver checkAndSortByVersion: descriptors) equals: nil
 ]
 
 { #category : 'tests' }
@@ -96,12 +84,9 @@ NexusSemanticVersioningDependencyConflictResolverTest >> testCheckAndSortByVersi
 	descriptors := {
 		               (Dictionary with: #version -> '1.0.0-alpha').
 		               (Dictionary with: #version -> '1.0.0-beta').
-		               (Dictionary with: #version -> '1.0.0-rc') }
-		               asOrderedCollection.
+		               (Dictionary with: #version -> '1.0.0-rc') } asOrderedCollection.
 
-	self
-		assert: (resolver checkAndSortByVersion: descriptors)
-		equals: nil
+	self assert: (resolver checkAndSortByVersion: descriptors) equals: nil
 ]
 
 { #category : 'tests' }
@@ -112,11 +97,9 @@ NexusSemanticVersioningDependencyConflictResolverTest >> testCheckAndSortByVersi
 		               (Dictionary with: #version -> '0.1').
 		               (Dictionary with: #version -> '1.0.1').
 		               (Dictionary with: #version -> '1.1.a').
-		               (Dictionary with: #version -> '1.1.0') }
-		               asOrderedCollection.
+		               (Dictionary with: #version -> '1.1.0') } asOrderedCollection.
 
-	sorted := (resolver checkAndSortByVersion: descriptors) collect:
-		          #value.
+	sorted := (resolver checkAndSortByVersion: descriptors) collect: #value.
 
 	self assert: sorted equals: descriptors
 ]
@@ -129,11 +112,9 @@ NexusSemanticVersioningDependencyConflictResolverTest >> testCheckAndSortByVersi
 	descriptors := {
 		               (Dictionary with: #version -> '1.0.0-alpha').
 		               (Dictionary with: #version -> '1.0.0-beta').
-		               (Dictionary with: #version -> '1.0.0') }
-		               asOrderedCollection.
+		               (Dictionary with: #version -> '1.0.0') } asOrderedCollection.
 
-	sorted := (resolver checkAndSortByVersion: descriptors) collect:
-		          #value.
+	sorted := (resolver checkAndSortByVersion: descriptors) collect: #value.
 
 	self assert: sorted equals: { descriptors last } asOrderedCollection
 ]
@@ -191,9 +172,7 @@ NexusSemanticVersioningDependencyConflictResolverTest >> testParseVersion [
 { #category : 'tests' }
 NexusSemanticVersioningDependencyConflictResolverTest >> testParseVersionWithSuffix [
 
-	self
-		assert: (resolver parseVersion: '1.2.3-alpha')
-		equals: { 1. 2. 3. '-alpha' }
+	self assert: (resolver parseVersion: '1.2.3-alpha') equals: { 1. 2. 3. '-alpha' }
 ]
 
 { #category : 'tests' }
@@ -222,26 +201,21 @@ NexusSemanticVersioningDependencyConflictResolverTest >> testResolveConflictsOn 
 		             with: 'net:versioned' -> {
 				             (Dictionary with: #version -> '8.7.5').
 				             (Dictionary with: #version -> '5.3.9').
-				             (Dictionary with: #version -> '10.2.0-rc') }
-				             asOrderedCollection
+				             (Dictionary with: #version -> '10.2.0-rc') } asOrderedCollection
 		             with: 'org:example' -> {
 				             (Dictionary with: #version -> '1.0.0').
 				             (Dictionary with: #version -> '2.0.0').
-				             (Dictionary with: #version -> '1.1.0') }
-				             asOrderedCollection
+				             (Dictionary with: #version -> '1.1.0') } asOrderedCollection
 		             with: 'com:potato' -> {
 				             (Dictionary with: #version -> '2.39.451e-rc').
-				             (Dictionary with: #version -> '2.39.452e-rc') }
-				             asOrderedCollection.
+				             (Dictionary with: #version -> '2.39.452e-rc') } asOrderedCollection.
 
 	resolver resolveConflicts: conflicts on: (resolved := Dictionary new).
 
 	self assert: resolved equals: (Dictionary
-			 with:
-			 'net:versioned' -> (Dictionary with: #version -> '10.2.0-rc')
+			 with: 'net:versioned' -> (Dictionary with: #version -> '10.2.0-rc')
 			 with: 'org:example' -> (Dictionary with: #version -> '2.0.0')
-			 with:
-			 'com:potato' -> (Dictionary with: #version -> '2.39.452e-rc'))
+			 with: 'com:potato' -> (Dictionary with: #version -> '2.39.452e-rc'))
 ]
 
 { #category : 'tests' }
@@ -252,17 +226,14 @@ NexusSemanticVersioningDependencyConflictResolverTest >> testResolveConflictsOnU
 		             with: 'net:versioned' -> {
 				             (Dictionary with: #version -> '8.7.5').
 				             (Dictionary with: #version -> '5.3.9').
-				             (Dictionary with: #version -> '10.2.0-rc') }
-				             asOrderedCollection
+				             (Dictionary with: #version -> '10.2.0-rc') } asOrderedCollection
 		             with: 'org:example' -> {
 				             (Dictionary with: #version -> '1.0.0').
 				             (Dictionary with: #version -> '2.0.0').
-				             (Dictionary with: #version -> '1.1.0') }
-				             asOrderedCollection
+				             (Dictionary with: #version -> '1.1.0') } asOrderedCollection
 		             with: 'com:potato' -> {
 				             (Dictionary with: #version -> '2.39.451e-rc').
-				             (Dictionary with: #version -> '2.39.452e-rc') }
-				             asOrderedCollection.
+				             (Dictionary with: #version -> '2.39.452e-rc') } asOrderedCollection.
 
 	resolver useOldest.
 	resolver resolveConflicts: conflicts on: (resolved := Dictionary new).
@@ -270,8 +241,7 @@ NexusSemanticVersioningDependencyConflictResolverTest >> testResolveConflictsOnU
 	self assert: resolved equals: (Dictionary
 			 with: 'net:versioned' -> (Dictionary with: #version -> '5.3.9')
 			 with: 'org:example' -> (Dictionary with: #version -> '1.0.0')
-			 with:
-			 'com:potato' -> (Dictionary with: #version -> '2.39.451e-rc'))
+			 with: 'com:potato' -> (Dictionary with: #version -> '2.39.451e-rc'))
 ]
 
 { #category : 'tests' }
@@ -282,25 +252,19 @@ NexusSemanticVersioningDependencyConflictResolverTest >> testResolveConflictsOnW
 		             with: 'net:versioned' -> {
 				             (Dictionary with: #version -> '8.7.5').
 				             (Dictionary with: #version -> '5.3.9').
-				             (Dictionary with: #version -> '10.2.0-rc') }
-				             asOrderedCollection
+				             (Dictionary with: #version -> '10.2.0-rc') } asOrderedCollection
 		             with: 'org:example' -> {
 				             (Dictionary with: #version -> 'awfulVersion').
 				             (Dictionary with: #version -> 'awesomeVersion').
-				             (Dictionary with: #version -> 'worstVersion') }
-				             asOrderedCollection
+				             (Dictionary with: #version -> 'worstVersion') } asOrderedCollection
 		             with: 'com:potato' -> {
 				             (Dictionary with: #version -> '2b.39.451e-rc').
-				             (Dictionary with: #version -> '2a.39.451e-rc') }
-				             asOrderedCollection.
+				             (Dictionary with: #version -> '2a.39.451e-rc') } asOrderedCollection.
 
 	resolver resolveConflicts: conflicts on: (resolved := Dictionary new).
 
 	self assert: resolved equals: (Dictionary
-			 with:
-			 'net:versioned' -> (Dictionary with: #version -> '10.2.0-rc')
-			 with:
-			 'org:example' -> (Dictionary with: #version -> 'awfulVersion')
-			 with:
-			 'com:potato' -> (Dictionary with: #version -> '2b.39.451e-rc'))
+			 with: 'net:versioned' -> (Dictionary with: #version -> '10.2.0-rc')
+			 with: 'org:example' -> (Dictionary with: #version -> 'awfulVersion')
+			 with: 'com:potato' -> (Dictionary with: #version -> '2b.39.451e-rc'))
 ]

--- a/src/MooseNexus-Tests/NexusTestProject.class.st
+++ b/src/MooseNexus-Tests/NexusTestProject.class.st
@@ -1,0 +1,12 @@
+Class {
+	#name : 'NexusTestProject',
+	#superclass : 'NexusProject',
+	#category : 'MooseNexus-Tests',
+	#package : 'MooseNexus-Tests'
+}
+
+{ #category : 'accessing' }
+NexusTestProject >> language [
+
+	^ 'test'
+]

--- a/src/MooseNexus-Tests/NexusVersionLockingDependencyConflictResolverTest.class.st
+++ b/src/MooseNexus-Tests/NexusVersionLockingDependencyConflictResolverTest.class.st
@@ -23,23 +23,17 @@ NexusVersionLockingDependencyConflictResolverTest >> testResolveConflictsOn [
 		             with: 'org:example' -> {
 				             (Dictionary with: #version -> 'awfulVersion').
 				             (Dictionary with: #version -> 'awesomeVersion').
-				             (Dictionary with: #version -> 'worstVersion') }
-				             asOrderedCollection
+				             (Dictionary with: #version -> 'worstVersion') } asOrderedCollection
 		             with: 'com:potato' -> {
 				             (Dictionary with: #version -> '2b.39.451e-rc').
-				             (Dictionary with: #version -> '2a.39.451e-rc') }
-				             asOrderedCollection.
-	resolver locks: (Dictionary
-			 with: 'org:example' -> 'awesomeVersion'
-			 with: 'com:potato' -> '2a.39.451e-rc').
+				             (Dictionary with: #version -> '2a.39.451e-rc') } asOrderedCollection.
+	resolver locks: (Dictionary with: 'org:example' -> 'awesomeVersion' with: 'com:potato' -> '2a.39.451e-rc').
 
 	resolver resolveConflicts: conflicts on: (resolved := Dictionary new).
 
 	self assert: resolved equals: (Dictionary
-			 with:
-			 'org:example' -> (Dictionary with: #version -> 'awesomeVersion')
-			 with:
-			 'com:potato' -> (Dictionary with: #version -> '2a.39.451e-rc'))
+			 with: 'org:example' -> (Dictionary with: #version -> 'awesomeVersion')
+			 with: 'com:potato' -> (Dictionary with: #version -> '2a.39.451e-rc'))
 ]
 
 { #category : 'tests' }
@@ -50,19 +44,15 @@ NexusVersionLockingDependencyConflictResolverTest >> testResolveConflictsOnWithF
 		             with: 'org:example' -> {
 				             (Dictionary with: #version -> 'awfulVersion').
 				             (Dictionary with: #version -> 'awesomeVersion').
-				             (Dictionary with: #version -> 'worstVersion') }
-				             asOrderedCollection
+				             (Dictionary with: #version -> 'worstVersion') } asOrderedCollection
 		             with: 'com:potato' -> {
 				             (Dictionary with: #version -> '2b.39.451e-rc').
-				             (Dictionary with: #version -> '2a.39.451e-rc') }
-				             asOrderedCollection.
+				             (Dictionary with: #version -> '2a.39.451e-rc') } asOrderedCollection.
 	resolver locks: (Dictionary with: 'org:example' -> 'awesomeVersion').
 
 	resolver resolveConflicts: conflicts on: (resolved := Dictionary new).
 
 	self assert: resolved equals: (Dictionary
-			 with:
-			 'org:example' -> (Dictionary with: #version -> 'awesomeVersion')
-			 with:
-			 'com:potato' -> (Dictionary with: #version -> '2b.39.451e-rc'))
+			 with: 'org:example' -> (Dictionary with: #version -> 'awesomeVersion')
+			 with: 'com:potato' -> (Dictionary with: #version -> '2b.39.451e-rc'))
 ]

--- a/src/MooseNexus-UI/NexusDependencyConflictPresenter.class.st
+++ b/src/MooseNexus-UI/NexusDependencyConflictPresenter.class.st
@@ -56,14 +56,14 @@ NexusDependencyConflictPresenter >> initializePresenters [
 	idLabel := self newLabel label: conflictId.
 
 	versionRadioButtons := descriptors collect: [ :descriptor |
-		                       | version |
-		                       version := descriptor at: #version.
-		                       self newRadioButton
-			                       label: version;
-			                       whenActivatedDo: [
-				                       freezeLock ifFalse: [ self lock ].
-				                       lockedVersion := version ];
-			                       yourself ].
+			                       | version |
+			                       version := descriptor at: #version.
+			                       self newRadioButton
+				                       label: version;
+				                       whenActivatedDo: [
+						                       freezeLock ifFalse: [ self lock ].
+						                       lockedVersion := version ];
+				                       yourself ].
 	versionRadioButtons first associatedRadioButtons: versionRadioButtons.
 
 	lockButton := self newButton
@@ -108,8 +108,7 @@ NexusDependencyConflictPresenter >> unlock [
 NexusDependencyConflictPresenter >> updateWithResolverChoice: descriptor [
 
 	self freezeLock: true.
-	(self versionRadioButtons detect: [ :button |
-		 button label = (descriptor at: #version) ]) state: true.
+	(self versionRadioButtons detect: [ :button | button label = (descriptor at: #version) ]) state: true.
 	self freezeLock: false
 ]
 
@@ -122,7 +121,5 @@ NexusDependencyConflictPresenter >> versionRadioButtons [
 { #category : 'actions' }
 NexusDependencyConflictPresenter >> whenLockedVersionChangedDo: aBlock [
 
-	self
-		property: #lockedVersion
-		whenChangedDo: [ aBlock value: lockedVersion value: isLocked ]
+	self property: #lockedVersion whenChangedDo: [ aBlock value: lockedVersion value: isLocked ]
 ]

--- a/src/MooseNexus-UI/NexusDependencySelectionPresenter.class.st
+++ b/src/MooseNexus-UI/NexusDependencySelectionPresenter.class.st
@@ -25,8 +25,7 @@ NexusDependencySelectionPresenter >> applyResolver: resolver [
 	lockResolver fallbackResolver: resolver.
 	choices := lockResolver resolveConflicts: conflicts.
 	conflictList items do: [ :conflictPresenter |
-		conflictPresenter updateWithResolverChoice:
-			(choices at: conflictPresenter conflictId) ]
+		conflictPresenter updateWithResolverChoice: (choices at: conflictPresenter conflictId) ]
 ]
 
 { #category : 'layout' }
@@ -52,32 +51,23 @@ NexusDependencySelectionPresenter >> initialize [
 NexusDependencySelectionPresenter >> initializePresenters [
 
 	resolverConfig := self newDropList
-		                  items:
-			                  (NexusDependencyConflictResolver allSubclasses
-				                   reject: [ :class |
-					                   class isAbstract or: [
-							                   class
-							                   ==
-								                   NexusVersionLockingDependencyConflictResolver ] ]
+		                  items: (NexusDependencyConflictResolver allSubclasses
+				                   reject: [ :class | class isAbstract or: [ class == NexusVersionLockingDependencyConflictResolver ] ]
 				                   thenCollect: #new);
 		                  display: [ :item | item displayName ];
-		                  whenSelectedItemChangedDo: [ :item |
-			                  self applyResolver: item ].
+		                  whenSelectedItemChangedDo: [ :item | self applyResolver: item ].
 
-	conflictList := self newComponentList items:
-		                (conflicts associations collect: [ :conflict |
-			                 (self instantiate:
-				                  (NexusDependencyConflictPresenter on: conflict))
-				                 whenLockedVersionChangedDo: [ :version :isLocked |
-					                 isLocked
-						                 ifTrue: [
-						                 lockResolver addLock: conflict key -> version ]
-						                 ifFalse: [
-						                 lockResolver removeLock: conflict key ] ] ]).
+	conflictList := self newComponentList items: (conflicts associations collect: [ :conflict |
+				                 (self instantiate: (NexusDependencyConflictPresenter on: conflict)) whenLockedVersionChangedDo: [
+						                 :version
+						                 :isLocked |
+						                 isLocked
+							                 ifTrue: [ lockResolver addLock: conflict key -> version ]
+							                 ifFalse: [ lockResolver removeLock: conflict key ] ] ]).
 
 	applyButton := self newButton
 		               label: 'Apply';
-		               action: [  ]
+		               action: [ ]
 ]
 
 { #category : 'initialization' }

--- a/src/MooseNexus-UI/NexusImportModelDialog.class.st
+++ b/src/MooseNexus-UI/NexusImportModelDialog.class.st
@@ -36,8 +36,7 @@ NexusImportModelDialog >> defaultLayout [
 				   yourself)
 		  expand: false;
 		  add: foldersList withConstraints: [ :c | c padding: 10 ];
-		  add: ('Java importer:' asPresenter addStyle: 'title2')
-		  expand: false;
+		  add: ('Java importer:' asPresenter addStyle: 'title2') expand: false;
 		  add: (SpGridLayout new
 				   add: importerDropList at: 1 @ 1;
 				   add: importerPathField at: 2 @ 1 span: 2 @ 1;
@@ -59,8 +58,7 @@ NexusImportModelDialog >> initializeAddFolderPresenter [
 	addSubFolders := addFolderPresenter newButton
 		                 label: 'Add subfolders';
 		                 iconName: #add;
-		                 help:
-			                 'Add the direct subfolders of the chosen folder';
+		                 help: 'Add the direct subfolders of the chosen folder';
 		                 action: [ self openSubFoldersSelection ].
 
 	addFolderPresenter layout: (SpBoxLayout newLeftToRight

--- a/src/MooseNexus-UI/NexusModelSelectionPresenter.class.st
+++ b/src/MooseNexus-UI/NexusModelSelectionPresenter.class.st
@@ -50,8 +50,7 @@ NexusModelSelectionPresenter >> initializePresenters [
 	importButton := self newButton
 		                label: 'Import';
 		                disable;
-		                action: [
-			                nexusProject importModel: modelsList selectedItem ].
+		                action: [ nexusProject importModel: modelsList selectedItem ].
 
 	self initializeLabels.
 
@@ -83,16 +82,11 @@ NexusModelSelectionPresenter >> updateForSelectedModel [
 { #category : 'updating' }
 NexusModelSelectionPresenter >> updateLabels [
 
-	commentLabel label:
-		'Comment: ' , (modelsList selectedItem at: 'comment').
-	timestampLabel label:
-		'Timestamp: ' , (modelsList selectedItem at: 'timestamp').
-	famixVersionLabel label:
-		'Famix version: ' , (modelsList selectedItem at: 'famixVersion').
-	fileSizeLabel label:
-		'File size: ' , (nexusProject directory asFileReference / 'models'
-		 / (modelsList selectedItem at: 'name')) size
-			humanReadableByteSizeString
+	commentLabel label: 'Comment: ' , (modelsList selectedItem at: 'comment').
+	timestampLabel label: 'Timestamp: ' , (modelsList selectedItem at: 'timestamp').
+	famixVersionLabel label: 'Famix version: ' , (modelsList selectedItem at: 'famixVersion').
+	fileSizeLabel label: 'File size: '
+		, (nexusProject directory asFileReference / 'models' / (modelsList selectedItem at: 'name')) size humanReadableByteSizeString
 ]
 
 { #category : 'updating' }

--- a/src/MooseNexus/NexusDependencyConflictResolverWithFallback.class.st
+++ b/src/MooseNexus/NexusDependencyConflictResolverWithFallback.class.st
@@ -23,8 +23,7 @@ NexusDependencyConflictResolverWithFallback class >> isAbstract [
 { #category : 'accessing' }
 NexusDependencyConflictResolverWithFallback >> fallbackResolver [
 
-	^ fallbackResolver ifNil: [
-		  fallbackResolver := self class newDefaultResolver ]
+	^ fallbackResolver ifNil: [ fallbackResolver := self class newDefaultResolver ]
 ]
 
 { #category : 'accessing' }

--- a/src/MooseNexus/NexusDockerVerveineJRunner.class.st
+++ b/src/MooseNexus/NexusDockerVerveineJRunner.class.st
@@ -19,11 +19,9 @@ NexusDockerVerveineJRunner >> run [
 	| returnCode |
 	returnCode := LibC runCommand: self writeCommand.
 	returnCode == 0 ifFalse: [
-		returnCode == 32000 ifTrue: [
-			Error signal: 'Docker must be running' ].
-		"look for Docker or Shell error codes to understand your issue"
-		Error signal:
-			'Failed to create the model, error code: ' , returnCode asString ].
+			returnCode == 32000 ifTrue: [ Error signal: 'Docker must be running' ].
+			"look for Docker or Shell error codes to understand your issue"
+			Error signal: 'Failed to create the model, error code: ' , returnCode asString ].
 
 	"VerveineJ-Docker outputs the file in the sources directory"
 	^ 'sources/' , self class outputFilename , '.' , self format
@@ -46,9 +44,7 @@ NexusDockerVerveineJRunner >> version: aString [
 NexusDockerVerveineJRunner >> writeCommand [
 
 	^ String streamContents: [ :s |
-		  s << 'docker run --rm -v ' << target << '/sources:/src -v '
-		  << target
-		  << '/dependencies:/dependency ghcr.io/evref-bl/verveinej:'
-		  << self version << ' '.
-		  self printOptionsOn: s ]
+			  s << 'docker run --rm -v ' << target << '/sources:/src -v ' << target
+			  << '/dependencies:/dependency ghcr.io/evref-bl/verveinej:' << self version << ' '.
+			  self printOptionsOn: s ]
 ]

--- a/src/MooseNexus/NexusFirstFoundDependencyConflictResolver.class.st
+++ b/src/MooseNexus/NexusFirstFoundDependencyConflictResolver.class.st
@@ -19,6 +19,5 @@ NexusFirstFoundDependencyConflictResolver >> displayName [
 { #category : 'resolving' }
 NexusFirstFoundDependencyConflictResolver >> resolveConflicts: conflicts on: dependencies [
 
-	conflicts keysAndValuesDo: [ :groupAndName :descriptors |
-		dependencies at: groupAndName put: descriptors first ]
+	conflicts keysAndValuesDo: [ :groupAndName :descriptors | dependencies at: groupAndName put: descriptors first ]
 ]

--- a/src/MooseNexus/NexusGradleProjectImporter.class.st
+++ b/src/MooseNexus/NexusGradleProjectImporter.class.st
@@ -48,8 +48,7 @@ NexusGradleProjectImporter >> findGradleCommand [
 
 	OSPlatform current isWindows
 		ifTrue: [ directory / 'gradlew.bat' ifExists: [ ^ 'gradlew.bat' ] ]
-		ifFalse: [ "assume *nix"
-		directory / 'gradlew' ifExists: [ ^ './gradlew' ] ].
+		ifFalse: [ "assume *nix" directory / 'gradlew' ifExists: [ ^ './gradlew' ] ].
 	"assume gradle is installed"
 	^ 'gradle'
 ]
@@ -59,12 +58,11 @@ NexusGradleProjectImporter >> groovyCodeForDependencies [
 	"Code to insert into a build.gradle file to get the flat list of dependencies."
 
 	^ String streamContents: [ :s |
-		  s << 'tasks.register("' << self class taskName << '") {
+			  s << 'tasks.register("' << self class taskName << '") {
 	doLast {
 		def rootDirPath = rootDir.canonicalPath
 		allprojects.findAll { it.projectDir.canonicalPath.startsWith(rootDirPath) }.each { project ->
-			println "-${' << self groupCode << '}:${' << self nameCode
-		  << '}:${' << self versionCode << '}"
+			println "-${' << self groupCode << '}:${' << self nameCode << '}:${' << self versionCode << '}"
 			def projectDirPath = project.projectDir.canonicalPath
 			if (projectDirPath.equals(rootDirPath)) {
 				println "."
@@ -114,13 +112,12 @@ NexusGradleProjectImporter >> kotlinCodeForDependencies [
 	Kotlin is sensitive to line endings, so they are removed for convenience."
 
 	^ String streamContents: [ :s |
-		  s << 'tasks.register("' << self class taskName
-		  <<
-		  '") { doLast { val rootDirPath = rootDir.canonicalPath; allprojects.filter { it.projectDir.canonicalPath.startsWith(rootDirPath) }.forEach { project -> println("-${'
-		  << self groupCode << '}:${' << self nameCode << '}:${'
-		  << self versionCode
-		  <<
-		  '}"); val projectDirPath = project.projectDir.canonicalPath; if (projectDirPath.equals(rootDirPath)) { println(".") } else { println(projectDirPath.substring(rootDirPath.length + 1)) }; configurations.filter { it.isCanBeResolved }.forEach { configuration -> val scope = configuration.name; configuration.resolvedConfiguration.resolvedArtifacts.forEach { artifact -> val group = artifact.moduleVersion.id.group; val name = artifact.name; val type = artifact.extension ?: "jar"; val version = artifact.moduleVersion.id.version; val path = artifact.file.absolutePath; /* forces artifact download */ println("$group:$name:$type:$version:$scope:$path") }}}}}' ]
+			  s << 'tasks.register("' << self class taskName
+			  <<
+			  '") { doLast { val rootDirPath = rootDir.canonicalPath; allprojects.filter { it.projectDir.canonicalPath.startsWith(rootDirPath) }.forEach { project -> println("-${'
+			  << self groupCode << '}:${' << self nameCode << '}:${' << self versionCode
+			  <<
+			  '}"); val projectDirPath = project.projectDir.canonicalPath; if (projectDirPath.equals(rootDirPath)) { println(".") } else { println(projectDirPath.substring(rootDirPath.length + 1)) }; configurations.filter { it.isCanBeResolved }.forEach { configuration -> val scope = configuration.name; configuration.resolvedConfiguration.resolvedArtifacts.forEach { artifact -> val group = artifact.moduleVersion.id.group; val name = artifact.name; val type = artifact.extension ?: "jar"; val version = artifact.moduleVersion.id.version; val path = artifact.file.absolutePath; /* forces artifact download */ println("$group:$name:$type:$version:$scope:$path") }}}}}' ]
 ]
 
 { #category : 'accessing' }
@@ -156,39 +153,35 @@ directory
 	index := 2.
 
 	[ "project info starts at third line at the earliest, after the line '> Task ...'"
-	(line := lines at: (index := index + 1)) isNotEmpty and: [
-		line first == $- ] ] whileFalse.
+	(line := lines at: (index := index + 1)) isNotEmpty and: [ line first == $- ] ] whileFalse.
 
 	[ (line := lines at: index) isNotEmpty ] whileTrue: [
-		| group name version descriptor dependencies |
-		"read project descriptor"
-		descriptor := $: split: line allButFirst.
-		group := descriptor first ifEmpty: [ 'unknown' ].
-		name := descriptor second.
-		version := descriptor third.
+			| group name version descriptor dependencies |
+			"read project descriptor"
+			descriptor := $: split: line allButFirst.
+			group := descriptor first ifEmpty: [ 'unknown' ].
+			name := descriptor second.
+			version := descriptor third.
 
-		"register the project with its version; project name is unique so this never overwrites"
-		descriptor := Dictionary with: #version -> version.
-		project projects at: group at: name put: descriptor.
+			"register the project with its version; project name is unique so this never overwrites"
+			descriptor := Dictionary with: #version -> version.
+			project projects at: group at: name put: descriptor.
 
-		"read project location, relative to the directory"
-		descriptor at: #path put: (lines at: (index := index + 1)).
+			"read project location, relative to the directory"
+			descriptor at: #path put: (lines at: (index := index + 1)).
 
-		"read dependencies per scope"
-		dependencies := Dictionary new.
-		[
-		(line := lines at: (index := index + 1)) isEmpty or: [
-			line first == $- ] ] whileFalse: [ "resolve the descriptor: 'group:name:type:version:scope:path'"
-			| mapping |
-			mapping := self resolve: line.
-			dependencies
-				at: mapping key
-				ifPresent: [ :descriptors | descriptors add: mapping value ]
-				ifAbsentPut: [ OrderedCollection with: mapping value ] ].
+			"read dependencies per scope"
+			dependencies := Dictionary new.
+			[ (line := lines at: (index := index + 1)) isEmpty or: [ line first == $- ] ] whileFalse: [ "resolve the descriptor: 'group:name:type:version:scope:path'"
+					| mapping |
+					mapping := self resolve: line.
+					dependencies
+						at: mapping key
+						ifPresent: [ :descriptors | descriptors add: mapping value ]
+						ifAbsentPut: [ OrderedCollection with: mapping value ] ].
 
-		"the current project has been fully parsed
-		save the dependencies as arrays for JSON compatibility"
-		descriptor at: #dependencies put: (dependencies collect: #asArray) ]
+			"the current project has been fully parsed, save the dependencies as arrays for JSON compatibility"
+			descriptor at: #dependencies put: (dependencies collect: #asArray) ]
 ]
 
 { #category : 'reading' }
@@ -203,17 +196,14 @@ NexusGradleProjectImporter >> read [
 	originalSize := buildFile size. "to restore it later"
 
 	^ [ "append code to the build file for a task to extract resolved dependencies"
-	  buildFile writeStreamDo: [ :ws |
-		  ws setToEnd crlf << (buildFile extension = 'kts'
-			   ifTrue: [ self kotlinCodeForDependencies ]
-			   ifFalse: [ self groovyCodeForDependencies ]) ].
+		  buildFile writeStreamDo: [ :ws |
+				  ws setToEnd crlf << (buildFile extension = 'kts'
+					   ifTrue: [ self kotlinCodeForDependencies ]
+					   ifFalse: [ self groovyCodeForDependencies ]) ].
 
-	  "execute the task we inserted and return the raw terminal output"
-	  LibC resultOfCommand:
-		  'cd "' , directory pathString , '" && ' , gradleCmd , ' '
-		  , self class taskName ] ensure: [ "restore the original build file"
-		  (File named: buildFile fullName) writeStreamDo: [ :ws |
-			  ws truncate: originalSize ] ]
+		  "execute the task we inserted and return the raw terminal output"
+		  LibC resultOfCommand: 'cd "' , directory pathString , '" && ' , gradleCmd , ' ' , self class taskName ] ensure: [ "restore the original build file"
+		  (File named: buildFile fullName) writeStreamDo: [ :ws | ws truncate: originalSize ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/MooseNexus/NexusGradleRepository.class.st
+++ b/src/MooseNexus/NexusGradleRepository.class.st
@@ -15,9 +15,7 @@ Class {
 { #category : 'accessing' }
 NexusGradleRepository class >> default [
 
-	^ default ifNil: [
-		  default := self new directory:
-			             '.gradle/caches/modules-2/files-2.1' ]
+	^ default ifNil: [ default := self new directory: '.gradle/caches/modules-2/files-2.1' ]
 ]
 
 { #category : 'resolving' }
@@ -25,14 +23,12 @@ NexusGradleRepository >> findGroup: group name: name version: version type: type
 	"Search for an artifact (a file) based on its descriptor."
 
 	| artifactDirectory fileName |
-	(artifactDirectory := FileLocator home / directory / group / name
-	                      / version) ifAbsent: [ ^ nil ].
+	(artifactDirectory := FileLocator home / directory / group / name / version) ifAbsent: [ ^ nil ].
 	fileName := name , '-' , version , '.' , type.
 
 	"Gradle can have multiple directories named with a UUID at this level,
 	any will do (make an issue if not!) as long as it contains the artifact."
-	artifactDirectory directories do: [ :dir |
-		dir / fileName ifExists: [ :artifact | ^ artifact ] ].
+	artifactDirectory directories do: [ :dir | dir / fileName ifExists: [ :artifact | ^ artifact ] ].
 	^ nil
 ]
 
@@ -49,11 +45,11 @@ NexusGradleRepository >> resolve: descriptor [
 	path := parts at: 6.
 
 	artifact := path asFileReference ifAbsent: [
-		            (self
-			             findGroup: group
-			             name: name
-			             version: version
-			             type: type) ifNil: [ ^ nil ] ].
+			            (self
+				             findGroup: group
+				             name: name
+				             version: version
+				             type: type) ifNil: [ ^ nil ] ].
 
 	^ group -> (Dictionary
 		   with: #name -> name

--- a/src/MooseNexus/NexusManagedProject.class.st
+++ b/src/MooseNexus/NexusManagedProject.class.st
@@ -56,8 +56,7 @@ NexusManagedProject class >> knownLanguages [
 { #category : 'querying' }
 NexusManagedProject >> determineGroup [
 
-	projects size == 1 ifFalse: [
-		Error signal: 'Can only determine group if only one is declared' ].
+	projects size == 1 ifFalse: [ Error signal: 'Can only determine group if only one is declared' ].
 	projects keysDo: [ :key | ^ key ]
 ]
 
@@ -66,33 +65,27 @@ NexusManagedProject >> determineLanguage [
 
 	| knownLanguages candidates sourceDirectory |
 	knownLanguages := self class knownLanguages.
-	(projects isEmpty or: [ projects anyOne isEmpty ]) ifTrue: [
-		Error signal: 'Cannot determine language without any project' ].
+	(projects isEmpty or: [ projects anyOne isEmpty ]) ifTrue: [ Error signal: 'Cannot determine language without any project' ].
 	candidates := Set new.
 	sourceDirectory := self projectSourceDirectory.
 
 	"check if this project directory has sources"
 	sourceDirectory / 'src/main' ifExists: [ :mainDirectory |
-		knownLanguages do: [ :lang |
-			mainDirectory / lang ifExists: [ candidates add: lang ] ] ].
+		knownLanguages do: [ :lang | mainDirectory / lang ifExists: [ candidates add: lang ] ] ].
 
 	"check the sources of each project"
 	projects do: [ :projectGroup |
-		projectGroup keysDo: [ :projectName |
-			sourceDirectory / projectName ifExists: [ :projectDirectory |
-				projectDirectory / 'src/main' ifExists: [ :mainDirectory |
-					knownLanguages do: [ :lang |
-						mainDirectory / lang ifExists: [ candidates add: lang ] ] ] ] ] ].
+			projectGroup keysDo: [ :projectName |
+					sourceDirectory / projectName ifExists: [ :projectDirectory |
+							projectDirectory / 'src/main' ifExists: [ :mainDirectory |
+								knownLanguages do: [ :lang | mainDirectory / lang ifExists: [ candidates add: lang ] ] ] ] ] ].
 
-	candidates ifEmpty: [
-		Error signal: 'Could not determine language automatically' ].
+	candidates ifEmpty: [ Error signal: 'Could not determine language automatically' ].
 	candidates size == 1 ifFalse: [
-		Warning signal: (String streamContents: [ :s |
-				 s << 'Multiple languages detected: `'.
-				 candidates
-					 do: [ :candidate | s << candidate ]
-					 separatedBy: [ s << ', ' ].
-				 s << '`, proceed to choose the first one' ]) ].
+			Warning signal: (String streamContents: [ :s |
+						 s << 'Multiple languages detected: `'.
+						 candidates do: [ :candidate | s << candidate ] separatedBy: [ s << ', ' ].
+						 s << '`, proceed to choose the first one' ]) ].
 	^ candidates anyOne
 ]
 
@@ -109,15 +102,13 @@ NexusManagedProject >> determineVersion [
 
 	| theVersion |
 	(projects isNotEmpty and: [ projects anyOne isNotEmpty ]) ifFalse: [
-		Error signal:
-			'Cannot determine version because there are no managed projects' ].
+		Error signal: 'Cannot determine version because there are no managed projects' ].
 	"verify all managed projects declare the same version"
 	theVersion := projects anyOne anyOne at: #version.
 	projects do: [ :projectGroup |
-		projectGroup do: [ :descriptor |
-			(descriptor at: #version) = theVersion ifFalse: [
-				Error signal:
-					'Can only determine version if all managed projects declare the same one' ] ] ].
+			projectGroup do: [ :descriptor |
+					(descriptor at: #version) = theVersion ifFalse: [
+						Error signal: 'Can only determine version if all managed projects declare the same one' ] ] ].
 	^ theVersion
 ]
 
@@ -157,12 +148,9 @@ NexusManagedProject >> projectDependenciesDo: aBlock [
 	"Iterate over the group, name and descriptor of all project dependencies"
 
 	self projects do: [ :projectGroup |
-		projectGroup do: [ :projectDescriptor |
-			(projectDescriptor at: #dependencies) keysAndValuesDo: [
-				:dependencyGroup
-				:descriptors |
-				descriptors do: [ :descriptor |
-					aBlock value: dependencyGroup value: descriptor ] ] ] ]
+			projectGroup do: [ :projectDescriptor |
+					(projectDescriptor at: #dependencies) keysAndValuesDo: [ :dependencyGroup :descriptors |
+						descriptors do: [ :descriptor | aBlock value: dependencyGroup value: descriptor ] ] ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/MooseNexus/NexusManagedProjectImporter.class.st
+++ b/src/MooseNexus/NexusManagedProjectImporter.class.st
@@ -55,23 +55,17 @@ NexusManagedProjectImporter >> flatDependencies [
 	conflicts := Dictionary new.
 
 	project projectDependenciesDo: [ :dependencyGroup :descriptor |
-		| key |
-		key := dependencyGroup , ':' , (descriptor at: #name).
-		conflicts
-			at: key
-			ifPresent: [ :conflictList | conflictList add: descriptor ]
-			ifAbsent: [
-				dependencies
-					at: key
-					ifPresent: [ :exisiting |
-						(exisiting at: #version) = (descriptor at: #version) ifFalse: [ "new conflict"
-							conflicts at: key put: (OrderedCollection
-									 with: (dependencies removeKey: key)
-									 with: descriptor) ] ]
-					ifAbsentPut: [ descriptor copyWith: #group -> dependencyGroup ] ] ].
+			| key |
+			key := dependencyGroup , ':' , (descriptor at: #name).
+			conflicts at: key ifPresent: [ :conflictList | conflictList add: descriptor ] ifAbsent: [
+					dependencies
+						at: key
+						ifPresent: [ :exisiting |
+								(exisiting at: #version) = (descriptor at: #version) ifFalse: [ "new conflict"
+									conflicts at: key put: (OrderedCollection with: (dependencies removeKey: key) with: descriptor) ] ]
+						ifAbsentPut: [ descriptor copyWith: #group -> dependencyGroup ] ] ].
 
-	conflicts ifNotEmpty: [
-		self resolveDependencyConflicts: conflicts on: dependencies ].
+	conflicts ifNotEmpty: [ self resolveDependencyConflicts: conflicts on: dependencies ].
 
 	^ dependencies asArray
 ]
@@ -118,20 +112,14 @@ NexusManagedProjectImporter >> read [
 NexusManagedProjectImporter >> resolve: descriptor [
 	"Attempts to find the local path to an artifact based on the descriptor."
 
-	localRepositories do: [ :repository |
-		(repository resolve: descriptor) ifNotNil: [ :mapping | ^ mapping ] ].
+	localRepositories do: [ :repository | (repository resolve: descriptor) ifNotNil: [ :mapping | ^ mapping ] ].
 	Error signal: 'Could not find dependency: ' , descriptor
 ]
 
 { #category : 'querying' }
 NexusManagedProjectImporter >> resolveDependencyConflicts: conflicts on: dependencies [
 
-	dependencyConflictResolver
-		ifNotNil: [
-			dependencyConflictResolver
-				resolveConflicts: conflicts
-				on: dependencies ]
-		ifNil: [
+	dependencyConflictResolver ifNotNil: [ dependencyConflictResolver resolveConflicts: conflicts on: dependencies ] ifNil: [
 			self shouldBeImplemented.
 			"TODO link presenter choices with actual result"
 			(NexusDependencySelectionPresenter on: conflicts) open ]

--- a/src/MooseNexus/NexusMavenProjectImporter.class.st
+++ b/src/MooseNexus/NexusMavenProjectImporter.class.st
@@ -22,8 +22,7 @@ NexusMavenProjectImporter >> findMavenCommand [
 
 	OSPlatform current isWindows
 		ifTrue: [ directory / 'mvnw.cmd' ifExists: [ ^ 'mvnw.cmd' ] ]
-		ifFalse: [ "assume *nix"
-		directory / 'mvnw' ifExists: [ ^ './mvnw' ] ].
+		ifFalse: [ "assume *nix" directory / 'mvnw' ifExists: [ ^ './mvnw' ] ].
 	"assume maven is installed"
 	^ 'mvn'
 ]
@@ -46,8 +45,7 @@ NexusMavenProjectImporter >> parse: raw [
 
 	| start |
 	start := 1.
-	[ (start := raw indexOf: $< startingAt: start) == 0 ] whileFalse: [
-		start := self parseProject: raw startingAt: start ]
+	[ (start := raw indexOf: $< startingAt: start) == 0 ] whileFalse: [ start := self parseProject: raw startingAt: start ]
 ]
 
 { #category : 'parsing' }
@@ -91,41 +89,41 @@ NexusMavenProjectImporter >> parseProject: raw startingAt: initialStart [
 	start == end
 		ifTrue: [ path := '.' ]
 		ifFalse: [
-			path := raw copyFrom: start to: end - 2.
-			"a project path is always relative to the root pom.xml,
-			but they can be from a different file hierarchy: ignore them"
-			skip := (directory / path isContainedBy: directory) not ].
+				path := raw copyFrom: start to: end - 2.
+				"a project path is always relative to the root pom.xml,
+				but they can be from a different file hierarchy: ignore them"
+				skip := (directory / path isContainedBy: directory) not ].
 
 	"find the first line with the dependencies"
 	start := (raw indexOfSubCollection: ']    ' startingAt: end + 1) + 5. "= ']    ' size"
 	projectDependencies := Dictionary new.
 
 	[ "collect and resolve all the dependencies"
-	| dependency |
-	"with Java >= 9, descriptors can be suffixed with ` -- module XYZ`, ignore it"
-	end := raw indexOfAnyOf: String crlf , ' ' startingAt: start + 1.
-	dependency := raw copyFrom: start to: end - 1. "= none | group:name:type:version:scope"
-	(raw at: end) == Character space ifTrue: [ "skip module description (>= 11 chars)"
-		end := raw indexOfAnyOf: String crlf startingAt: end + 11 ].
-	(skip or: [ dependency = 'none' ]) ifFalse: [
-		| mapping |
-		mapping := self resolve: dependency. "returns group -> (descriptor \ group)"
-		projectDependencies
-			at: mapping key
-			ifPresent: [ :descriptors | descriptors add: mapping value ]
-			ifAbsentPut: [ OrderedCollection with: mapping value ] ].
+		| dependency |
+		"with Java >= 9, descriptors can be suffixed with ` -- module XYZ`, ignore it"
+		end := raw indexOfAnyOf: String crlf , ' ' startingAt: start + 1.
+		dependency := raw copyFrom: start to: end - 1. "= none | group:name:type:version:scope"
+		(raw at: end) == Character space ifTrue: [ "skip module description (>= 11 chars)"
+			end := raw indexOfAnyOf: String crlf startingAt: end + 11 ].
+		(skip or: [ dependency = 'none' ]) ifFalse: [
+				| mapping |
+				mapping := self resolve: dependency. "returns group -> (descriptor \ group)"
+				projectDependencies
+					at: mapping key
+					ifPresent: [ :descriptors | descriptors add: mapping value ]
+					ifAbsentPut: [ OrderedCollection with: mapping value ] ].
 
-	"skip over '[INFO] ' (8 chars) and check if new line, indicating the end of the list
-	else start of next dependency descriptor is 3 spaces later"
-	String crlf includes: (raw at: (start := end + 11) - 3) ] whileFalse.
+		"skip over '[INFO] ' (8 chars) and check if new line, indicating the end of the list
+		else start of next dependency descriptor is 3 spaces later"
+		String crlf includes: (raw at: (start := end + 11) - 3) ] whileFalse.
 
 	"register the project with its version; projectName is unique so this never overwrites
 	save dependencies as arrays for JSON compatibility"
 	skip ifFalse: [
-		project projects at: group at: name put: (Dictionary
-				 with: #path -> path
-				 with: #version -> version
-				 with: #dependencies -> (projectDependencies collect: #asArray)) ].
+			project projects
+				at: group
+				at: name
+				put: (Dictionary with: #path -> path with: #version -> version with: #dependencies -> (projectDependencies collect: #asArray)) ].
 
 	"return the updated reading position"
 	^ start
@@ -136,7 +134,5 @@ NexusMavenProjectImporter >> read [
 	"Runs the `mvn` command using the `dependency:resolve` plugin.
 	Requires Maven to be installed."
 
-	^ LibC resultOfCommand:
-		  'cd "' , directory pathString , '" && ' , self findMavenCommand
-		  , ' --batch-mode dependency:resolve'
+	^ LibC resultOfCommand: 'cd "' , directory pathString , '" && ' , self findMavenCommand , ' --batch-mode dependency:resolve'
 ]

--- a/src/MooseNexus/NexusMavenRepository.class.st
+++ b/src/MooseNexus/NexusMavenRepository.class.st
@@ -31,21 +31,18 @@ NexusMavenRepository >> resolve: descriptor [
 	scope := parts at: 5.
 
 	"search for the directory"
-	pathString := String streamContents: [ :s |
-		              s << (group copyReplaceAll: '.' with: '/') << '/'
-		              << name << '/' << version ].
+	pathString := String streamContents: [ :s | s << (group copyReplaceAll: '.' with: '/') << '/' << name << '/' << version ].
 	homeDirectory := FileLocator home.
-	(theDirectory := homeDirectory / directory / pathString) ifAbsent: [
-		^ nil ].
+	(theDirectory := homeDirectory / directory / pathString) ifAbsent: [ ^ nil ].
 
 	"search for the artifact"
 	^ theDirectory / (name , '-' , version , '.' , type)
 		  ifExists: [ :file |
-			  group -> (Dictionary
-				   with: #name -> name
-				   with: #version -> version
-				   with: #type -> type
-				   with: #scope -> scope
-				   with: #path -> (file relativeTo: homeDirectory) pathString) ]
+				  group -> (Dictionary
+					   with: #name -> name
+					   with: #version -> version
+					   with: #type -> type
+					   with: #scope -> scope
+					   with: #path -> (file relativeTo: homeDirectory) pathString) ]
 		  ifAbsent: [ nil ]
 ]

--- a/src/MooseNexus/NexusModelBuilder.class.st
+++ b/src/MooseNexus/NexusModelBuilder.class.st
@@ -29,25 +29,23 @@ NexusModelBuilder >> build [
 	"Create the model"
 
 	[
-	| modelPath |
-	self setUp.
-	modelPath := self extractor run.
-	self registerModel: modelPath ] ensure: [ self cleanUp ]
+		| modelPath |
+		self setUp.
+		modelPath := self extractor run.
+		self registerModel: modelPath ] ensure: [ self cleanUp ]
 ]
 
 { #category : 'cleanup' }
 NexusModelBuilder >> cleanUp [
 	"delete temp directories"
 
-	(FileLocator home / project directory / 'dependencies')
-		ensureDeleteAll
+	(FileLocator home / project directory / 'dependencies') ensureDeleteAll
 ]
 
 { #category : 'accessing' }
 NexusModelBuilder >> extractor [
 
-	^ extractor ifNil: [
-		  extractor := NexusModelExtractor forLanguage: project language ]
+	^ extractor ifNil: [ extractor := NexusModelExtractor forLanguage: project language ]
 ]
 
 { #category : 'accessing' }
@@ -105,9 +103,7 @@ NexusModelBuilder >> registerModel: modelPath [
 	| projectDirectory source |
 	projectDirectory := FileLocator home / project directory.
 	source := projectDirectory / modelPath.
-	source moveTo:
-		((projectDirectory / 'models') ensureCreateDirectory
-		 / self modelName , source extension) ensureDelete.
+	source moveTo: ((projectDirectory / 'models') ensureCreateDirectory / self modelName , source extension) ensureDelete.
 
 	project addModel: (Dictionary
 			 with: 'name' -> self modelName
@@ -125,11 +121,11 @@ NexusModelBuilder >> setUp [
 	projectDirectory := home / project directory.
 
 	withDependencies ifTrue: [
-		dependencies := (projectDirectory / 'dependencies') createDirectory.
-		project dependencies do: [ :dependency |
-			| artifact |
-			artifact := home / (dependency at: #path).
-			artifact copyTo: dependencies / artifact basename ] ].
+			dependencies := (projectDirectory / 'dependencies') createDirectory.
+			project dependencies do: [ :dependency |
+					| artifact |
+					artifact := home / (dependency at: #path).
+					artifact copyTo: dependencies / artifact basename ] ].
 
 	self extractor target: projectDirectory pathString
 ]

--- a/src/MooseNexus/NexusModelExtractor.class.st
+++ b/src/MooseNexus/NexusModelExtractor.class.st
@@ -24,9 +24,7 @@ NexusModelExtractor class >> defaultImplementation [
 { #category : 'instance creation' }
 NexusModelExtractor class >> forLanguage: language [
 
-	self allSubclassesDo: [ :subclass |
-		(subclass canHandle: language) ifTrue: [
-			^ subclass defaultImplementation ] ].
+	self allSubclassesDo: [ :subclass | (subclass canHandle: language) ifTrue: [ ^ subclass defaultImplementation ] ].
 	Error signal: 'No NexusModelCreator for this language: ' , language
 ]
 

--- a/src/MooseNexus/NexusProject.class.st
+++ b/src/MooseNexus/NexusProject.class.st
@@ -75,6 +75,21 @@ NexusProject >> buildModel [
 ]
 
 { #category : 'accessing' }
+NexusProject >> coordinates [
+
+	^ NexusProjectCoordinates group: self group name: self name version: self version
+]
+
+{ #category : 'accessing' }
+NexusProject >> coordinates: aNexusProjectCoordinates [
+
+	self isRecorded ifTrue: [ Error signal: 'Cannot change project coordinates after recording the project in a repository' ].
+	group := aNexusProjectCoordinates group.
+	name := aNexusProjectCoordinates name.
+	version := aNexusProjectCoordinates version
+]
+
+{ #category : 'accessing' }
 NexusProject >> dependencies [
 
 	^ dependencies ifNil: [ dependencies := #(  ) ]
@@ -127,9 +142,9 @@ NexusProject >> group [
 ]
 
 { #category : 'accessing' }
-NexusProject >> group: aSymbol [
+NexusProject >> group: aString [
 
-	group := aSymbol
+	self coordinates: (NexusProjectCoordinates group: aString name: name version: version)
 ]
 
 { #category : 'setup' }
@@ -170,6 +185,12 @@ NexusProject >> isManagedProject [
 	^ false
 ]
 
+{ #category : 'testing' }
+NexusProject >> isRecorded [
+
+	^ directory notNil
+]
+
 { #category : 'accessing' }
 NexusProject >> language [
 	"Subclasses must return a lowercase string of the project's language name."
@@ -202,9 +223,9 @@ NexusProject >> name [
 ]
 
 { #category : 'accessing' }
-NexusProject >> name: aSymbol [
+NexusProject >> name: aString [
 
-	name := aSymbol
+	self coordinates: (NexusProjectCoordinates group: group name: aString version: version)
 ]
 
 { #category : 'printing' }
@@ -271,7 +292,7 @@ NexusProject >> version [
 { #category : 'accessing' }
 NexusProject >> version: aString [
 
-	version := aString
+	self coordinates: (NexusProjectCoordinates group: group name: name version: aString)
 ]
 
 { #category : 'properties' }

--- a/src/MooseNexus/NexusProject.class.st
+++ b/src/MooseNexus/NexusProject.class.st
@@ -33,8 +33,7 @@ Class {
 { #category : 'instance creation' }
 NexusProject class >> fromNexusDirectory: directory [
 
-	^ (self fromProperties: directory / 'properties.json') directory:
-		  (directory relativeTo: FileLocator home) pathString
+	^ (self fromProperties: directory / 'properties.json') directory: (directory relativeTo: FileLocator home) pathString
 ]
 
 { #category : 'instance creation' }
@@ -43,8 +42,7 @@ NexusProject class >> fromProperties: file [
 
 	| properties |
 	properties := file readStreamDo: [ :s | STON fromStream: s ].
-	^ ((properties at: #nature) asClassInEnvironment:
-		   self class environment) new readProperties: properties
+	^ ((properties at: #nature) asClassInEnvironment: self class environment) new readProperties: properties
 ]
 
 { #category : 'testing' }
@@ -59,12 +57,10 @@ NexusProject >> addModel: modelDescription [
 
 	| modelName models |
 	modelName := modelDescription at: 'name'.
-	models := self models reject: [ :desc |
-		          (desc at: 'name') = modelName ].
+	models := self models reject: [ :desc | (desc at: 'name') = modelName ].
 	models := models copyWith: modelDescription.
 
-	FileLocator home / directory / 'models.json' writeStreamDo: [ :s |
-		STON put: models asJsonOnStream: s ]
+	FileLocator home / directory / 'models.json' writeStreamDo: [ :s | STON put: models asJsonOnStream: s ]
 ]
 
 { #category : 'building' }
@@ -104,23 +100,19 @@ NexusProject >> dependencies: aDictionary [
 { #category : 'querying' }
 NexusProject >> determineGroup [
 
-	Error signal: 'Instance of ' , self className
-		, ' ignores how to determine the group'
+	Error signal: 'Instance of ' , self className , ' ignores how to determine the group'
 ]
 
 { #category : 'querying' }
 NexusProject >> determineName [
 
-	Error signal:
-		'Instance of ' , self className
-		, ' ignores how to determine the name'
+	Error signal: 'Instance of ' , self className , ' ignores how to determine the name'
 ]
 
 { #category : 'querying' }
 NexusProject >> determineVersion [
 
-	Error signal: 'Instance of ' , self className
-		, ' ignores how to determine the version'
+	Error signal: 'Instance of ' , self className , ' ignores how to determine the version'
 ]
 
 { #category : 'accessing' }
@@ -151,9 +143,7 @@ NexusProject >> group: aString [
 NexusProject >> importModel [
 	"There can be multiple models with different settings for the same project."
 
-	self models
-		ifEmpty: [ self inform: 'No models to import' ]
-		ifNotEmpty: [ :models |
+	self models ifEmpty: [ self inform: 'No models to import' ] ifNotEmpty: [ :models |
 			models size = 1 ifTrue: [ ^ self importModel: models first ].
 
 			"Open a presenter to choose a model to import."
@@ -169,13 +159,11 @@ NexusProject >> importModel: modelDescription [
 
 	FamixJSONFileImporter new
 		model: model;
-		inputFile: FileLocator home / directory / 'models'
-			/ (modelDescription at: 'name') , (modelDescription at: 'format');
+		inputFile: FileLocator home / directory / 'models' / (modelDescription at: 'name') , (modelDescription at: 'format');
 		runFilteredBy: FamixJavaImportingContext new importMaximum.
 
 	model install. "add to MooseModel root"
-	model rootFolder:
-		(FileLocator home / directory / 'sources') absolutePath pathString.
+	model rootFolder: (FileLocator home / directory / 'sources') absolutePath pathString.
 	^ model
 ]
 
@@ -212,8 +200,7 @@ NexusProject >> modelBuilder [
 { #category : 'enumerating' }
 NexusProject >> models [
 
-	^ FileLocator home / directory / 'models.json' readStreamDo: [ :s |
-		  STON fromStream: s ]
+	^ FileLocator home / directory / 'models.json' readStreamDo: [ :s | STON fromStream: s ]
 ]
 
 { #category : 'accessing' }
@@ -233,17 +220,11 @@ NexusProject >> printOn: stream [
 
 	super printOn: stream.
 	stream nextPut: $(.
-	group
-		ifNil: [ stream nextPutAll: '<group>' ]
-		ifNotNil: [ stream nextPutAll: group ].
+	group ifNil: [ stream nextPutAll: '<group>' ] ifNotNil: [ stream nextPutAll: group ].
 	stream nextPut: $:.
-	name
-		ifNil: [ stream nextPutAll: '<project>' ]
-		ifNotNil: [ stream nextPutAll: name ].
+	name ifNil: [ stream nextPutAll: '<project>' ] ifNotNil: [ stream nextPutAll: name ].
 	stream nextPut: $:.
-	version
-		ifNil: [ stream nextPutAll: '<version>' ]
-		ifNotNil: [ stream nextPutAll: version ].
+	version ifNil: [ stream nextPutAll: '<version>' ] ifNotNil: [ stream nextPutAll: version ].
 	stream nextPut: $)
 ]
 
@@ -270,9 +251,7 @@ NexusProject >> properties [
 { #category : 'properties' }
 NexusProject >> readProperties: properties [
 
-	properties keysAndValuesDo: [ :key :value |
-		key = #nature ifFalse: [
-			self perform: key asSymbol asMutator with: value ] ]
+	properties keysAndValuesDo: [ :key :value | key = #nature ifFalse: [ self perform: key asSymbol asMutator with: value ] ]
 ]
 
 { #category : 'enumerating' }

--- a/src/MooseNexus/NexusProjectCoordinates.class.st
+++ b/src/MooseNexus/NexusProjectCoordinates.class.st
@@ -1,0 +1,69 @@
+Class {
+	#name : 'NexusProjectCoordinates',
+	#superclass : 'Object',
+	#instVars : [
+		'group',
+		'name',
+		'version'
+	],
+	#category : 'MooseNexus-Project',
+	#package : 'MooseNexus',
+	#tag : 'Project'
+}
+
+{ #category : 'instance creation' }
+NexusProjectCoordinates class >> group: aGroup name: aName version: aVersion [
+
+	^ self new initializeGroup: aGroup name: aName version: aVersion
+]
+
+{ #category : 'comparing' }
+NexusProjectCoordinates >> = anObject [
+
+	self == anObject ifTrue: [ ^ true ].
+	anObject class = self class ifFalse: [ ^ false ].
+	^ anObject group = group and: [ anObject name = name and: [ anObject version = version ] ]
+]
+
+{ #category : 'accessing' }
+NexusProjectCoordinates >> group [
+
+	^ group
+]
+
+{ #category : 'comparing' }
+NexusProjectCoordinates >> hash [
+
+	^ group hash bitXor: (name hash bitXor: version hash)
+]
+
+{ #category : 'initialization' }
+NexusProjectCoordinates >> initializeGroup: aGroup name: aName version: aVersion [
+
+	group := aGroup.
+	name := aName.
+	version := aVersion
+]
+
+{ #category : 'accessing' }
+NexusProjectCoordinates >> name [
+
+	^ name
+]
+
+{ #category : 'printing' }
+NexusProjectCoordinates >> printOn: aStream [
+
+	aStream
+		nextPutAll: group;
+		nextPut: $:;
+		nextPutAll: name;
+		nextPut: $:;
+		nextPutAll: version
+]
+
+{ #category : 'accessing' }
+NexusProjectCoordinates >> version [
+
+	^ version
+]

--- a/src/MooseNexus/NexusProjectImporter.class.st
+++ b/src/MooseNexus/NexusProjectImporter.class.st
@@ -28,10 +28,8 @@ NexusProjectImporter class >> fromDirectory: directory [
 	Returns an instance of the appropriate class for importing the project."
 
 	self allSubclassesDo: [ :subclass |
-		(subclass isAbstract not and: [ subclass canHandle: directory ])
-			ifTrue: [ ^ subclass new directory: directory ] ].
-	Error signal:
-		'Cannot figure out nature of project in directory: ' , directory
+		(subclass isAbstract not and: [ subclass canHandle: directory ]) ifTrue: [ ^ subclass new directory: directory ] ].
+	Error signal: 'Cannot figure out nature of project in directory: ' , directory
 ]
 
 { #category : 'instance creation' }

--- a/src/MooseNexus/NexusRepository.class.st
+++ b/src/MooseNexus/NexusRepository.class.st
@@ -92,6 +92,15 @@ NexusRepository >> import: name fromDirectory: pathString [
 ]
 
 { #category : 'importing' }
+NexusRepository >> importCoordinates: coordinates fromDirectory: pathString [
+	"Import the project within the given directory and record it with explicit coordinates."
+
+	| project |
+	project := NexusProjectImporter importFromDirectory: pathString.
+	^ self recordProject: project coordinates: coordinates fromDirectory: pathString
+]
+
+{ #category : 'importing' }
 NexusRepository >> importFromDirectory: pathString [
 	"Import the project within the given directory and try to determine its name.
 	It is recommended that you specify the project name using `import:fromDirectory:`,
@@ -101,6 +110,13 @@ NexusRepository >> importFromDirectory: pathString [
 	project := NexusProjectImporter importFromDirectory: pathString.
 	self recordProject: project fromDirectory: pathString.
 	^ project
+]
+
+{ #category : 'importing' }
+NexusRepository >> importGroup: group name: name version: version fromDirectory: pathString [
+	"Import the project within the given directory and record it with explicit coordinates."
+
+	^ self importCoordinates: (NexusProjectCoordinates group: group name: name version: version) fromDirectory: pathString
 ]
 
 { #category : 'printing' }
@@ -159,18 +175,26 @@ NexusRepository >> projects [
 ]
 
 { #category : 'adding' }
+NexusRepository >> recordProject: project coordinates: coordinates fromDirectory: pathString [
+	"Set project coordinates before recording it in the repository."
+
+	project coordinates: coordinates.
+	^ self recordProject: project fromDirectory: pathString
+]
+
+{ #category : 'adding' }
 NexusRepository >> recordProject: project fromDirectory: pathString [
-	"Add the project to this repository, copying the sources from the given directory."
+	"Add project to the repository, copying sources from the given directory."
 
 	| projectDirectory |
 	(projectDirectory := self resolveDirectoryOf: project) ifExists: [
-		Warning signal:
-			'This project already exists in the given repository, proceed to overwrite it'.
-		projectDirectory deleteAll ].
+			Warning signal:
+				'This project already exists in given repository, proceed to overwrite it'.
+			projectDirectory deleteAll ].
 	project directory:
 		(projectDirectory relativeTo: FileLocator home) pathString.
 
-	"copy the project directory to the repository"
+	"copy project directory to repository"
 	pathString asFileReference copyAllTo:
 		(projectDirectory / 'sources/project') ensureCreateDirectory.
 
@@ -178,9 +202,21 @@ NexusRepository >> recordProject: project fromDirectory: pathString [
 	(projectDirectory / 'properties.json') ensureCreateFile
 		writeStreamDo: [ :stream | project writePropertiesOn: stream ].
 
-	"JSON list of models that were created, empty by default"
+	"JSON list of models created, empty by default"
 	(projectDirectory / 'models.json') ensureCreateFile writeStreamDo: [
-		:stream | stream nextPutAll: '[]' ]
+		:stream | stream nextPutAll: '[]' ].
+
+	^ project
+]
+
+{ #category : 'adding' }
+NexusRepository >> recordProject: project group: group name: name version: version fromDirectory: pathString [
+	"Set project coordinates before recording it in the repository."
+
+	^ self
+		  recordProject: project
+		  coordinates: (NexusProjectCoordinates group: group name: name version: version)
+		  fromDirectory: pathString
 ]
 
 { #category : 'enumerating' }

--- a/src/MooseNexus/NexusRepository.class.st
+++ b/src/MooseNexus/NexusRepository.class.st
@@ -45,8 +45,7 @@ Class {
 { #category : 'accessing' }
 NexusRepository class >> default [
 
-	^ default ifNil: [
-		  default := self new directory: FileLocator home / '.moose' ]
+	^ default ifNil: [ default := self new directory: FileLocator home / '.moose' ]
 ]
 
 { #category : 'accessing' }
@@ -66,17 +65,10 @@ NexusRepository >> group: group project: project version: version [
 	"Search the repository for the project with the specified group, project name and version."
 
 	| dir |
-	dir := directory / 'repository' / group ifAbsent: [
-		       NotFound signal:
-			       'Group `' , group , '`, not found in repository' ].
-	dir := dir / project ifAbsent: [
-		       NotFound signal:
-			       'Project `' , project , '` not found in group `' , group
-			       , '`' ].
+	dir := directory / 'repository' / group ifAbsent: [ NotFound signal: 'Group `' , group , '`, not found in repository' ].
+	dir := dir / project ifAbsent: [ NotFound signal: 'Project `' , project , '` not found in group `' , group , '`' ].
 	dir := dir / version ifAbsent: [
-		       NotFound signal:
-			       'Version `' , version , '` not found for project `'
-			       , project , '` in group `' , group , '`' ].
+		       NotFound signal: 'Version `' , version , '` not found for project `' , project , '` in group `' , group , '`' ].
 	^ NexusProject fromNexusDirectory: dir
 ]
 
@@ -132,25 +124,19 @@ NexusRepository >> printOn: stream [
 NexusRepository >> printProjectProperties: propertiesFile on: writeStream [
 
 	propertiesFile readStreamDo: [ :rs |
-		| properties |
-		properties := STON fromStream: rs.
-		writeStream << (properties at: #nature) << '('
-		<< (properties at: #group) << ':' << (properties at: #name) << ':'
-		<< (properties at: #version) << ')' ]
+			| properties |
+			properties := STON fromStream: rs.
+			writeStream << (properties at: #nature) << '(' << (properties at: #group) << ':' << (properties at: #name) << ':'
+			<< (properties at: #version) << ')' ]
 ]
 
 { #category : 'printing' }
 NexusRepository >> printProjects [
 
 	directory ifAbsent: [ ^ 'none' ].
-	^ self projectProperties
-		  ifEmpty: [ ^ 'none' ]
-		  ifNotEmpty: [ :projectProperties |
+	^ self projectProperties ifEmpty: [ ^ 'none' ] ifNotEmpty: [ :projectProperties |
 			  String streamContents: [ :s |
-				  projectProperties
-					  do: [ :properties |
-					  self printProjectProperties: properties on: s ]
-					  separatedBy: [ s cr ] ] ]
+				  projectProperties do: [ :properties | self printProjectProperties: properties on: s ] separatedBy: [ s cr ] ] ]
 ]
 
 { #category : 'enumerating' }
@@ -160,9 +146,8 @@ NexusRepository >> projectProperties [
 	| properties |
 	properties := OrderedCollection new.
 	(directory / 'repository') directories do: [ :groupDirectory |
-		groupDirectory directories do: [ :nameDirectory |
-			nameDirectory directories do: [ :versionDirectory |
-				properties add: versionDirectory / 'properties.json' ] ] ].
+			groupDirectory directories do: [ :nameDirectory |
+				nameDirectory directories do: [ :versionDirectory | properties add: versionDirectory / 'properties.json' ] ] ].
 	^ properties
 ]
 
@@ -170,8 +155,7 @@ NexusRepository >> projectProperties [
 NexusRepository >> projects [
 	"Returns all the projects managed by this repository."
 
-	^ self projectProperties collect: [ :properties |
-		  NexusProject fromProperties: properties ]
+	^ self projectProperties collect: [ :properties | NexusProject fromProperties: properties ]
 ]
 
 { #category : 'adding' }
@@ -188,23 +172,18 @@ NexusRepository >> recordProject: project fromDirectory: pathString [
 
 	| projectDirectory |
 	(projectDirectory := self resolveDirectoryOf: project) ifExists: [
-			Warning signal:
-				'This project already exists in given repository, proceed to overwrite it'.
+			Warning signal: 'This project already exists in given repository, proceed to overwrite it'.
 			projectDirectory deleteAll ].
-	project directory:
-		(projectDirectory relativeTo: FileLocator home) pathString.
+	project directory: (projectDirectory relativeTo: FileLocator home) pathString.
 
 	"copy project directory to repository"
-	pathString asFileReference copyAllTo:
-		(projectDirectory / 'sources/project') ensureCreateDirectory.
+	pathString asFileReference copyAllTo: (projectDirectory / 'sources/project') ensureCreateDirectory.
 
 	"write properties file useful for Nexus"
-	(projectDirectory / 'properties.json') ensureCreateFile
-		writeStreamDo: [ :stream | project writePropertiesOn: stream ].
+	(projectDirectory / 'properties.json') ensureCreateFile writeStreamDo: [ :stream | project writePropertiesOn: stream ].
 
 	"JSON list of models created, empty by default"
-	(projectDirectory / 'models.json') ensureCreateFile writeStreamDo: [
-		:stream | stream nextPutAll: '[]' ].
+	(projectDirectory / 'models.json') ensureCreateFile writeStreamDo: [ :stream | stream nextPutAll: '[]' ].
 
 	^ project
 ]
@@ -222,6 +201,5 @@ NexusRepository >> recordProject: project group: group name: name version: versi
 { #category : 'enumerating' }
 NexusRepository >> resolveDirectoryOf: project [
 
-	^ directory / 'repository' / project group / project name
-	  / project version
+	^ directory / 'repository' / project group / project name / project version
 ]

--- a/src/MooseNexus/NexusSemanticVersioningDependencyConflictResolver.class.st
+++ b/src/MooseNexus/NexusSemanticVersioningDependencyConflictResolver.class.st
@@ -28,19 +28,18 @@ NexusSemanticVersioningDependencyConflictResolver >> checkAndSortByVersion: desc
 	Versions are added to a set to ensure uniqueness after parsing.
 	Versions with a suffix are added to a bag without the suffix to count them."
 	listWithVersion := descriptors collectWithIndex: [ :descriptor :index |
-		                   | version |
-		                   version := self parseVersion:
-			                              (descriptor at: #version).
-		                   uniqueVersions add: version.
-		                   version size = 4 ifTrue: [ "version has suffix"
-			                   | suffixless |
-			                   suffixless := version allButLast.
-			                   versionsWithSuffix add: suffixless.
-			                   suffixedVersionIndices
-				                   at: suffixless
-				                   ifPresent: [ :list | list add: index ]
-				                   ifAbsentPut: [ OrderedCollection with: index ] ].
-		                   version -> descriptor ].
+			                   | version |
+			                   version := self parseVersion: (descriptor at: #version).
+			                   uniqueVersions add: version.
+			                   version size = 4 ifTrue: [ "version has suffix"
+					                   | suffixless |
+					                   suffixless := version allButLast.
+					                   versionsWithSuffix add: suffixless.
+					                   suffixedVersionIndices
+						                   at: suffixless
+						                   ifPresent: [ :list | list add: index ]
+						                   ifAbsentPut: [ OrderedCollection with: index ] ].
+			                   version -> descriptor ].
 
 	"This resolver considers itself unable to correctly select a version
 	if either of the two following conditions is true:"
@@ -55,15 +54,14 @@ NexusSemanticVersioningDependencyConflictResolver >> checkAndSortByVersion: desc
 	e.g. '1.0.0-alpha' cannot be compared to '1.0.0-beta'
 	this dependency can only be resolved if '1.0.0' also exists"
 	versionsWithSuffix doWithOccurrences: [ :version :count |
-		(uniqueVersions includes: version)
-			ifFalse: [ count > 1 ifTrue: [ ^ nil ] ]
-			ifTrue: [ "Gather the indices of the suffixed versions if the base version exists"
-				indicesToRemove addAll: (suffixedVersionIndices at: version) ] ].
+			(uniqueVersions includes: version)
+				ifFalse: [ count > 1 ifTrue: [ ^ nil ] ]
+				ifTrue: [ "Gather the indices of the suffixed versions if the base version exists"
+					indicesToRemove addAll: (suffixedVersionIndices at: version) ] ].
 
 	"Remove all suffixed versions from the choices,
 	this resolver should never pick one when a suffixless version is available."
-	(indicesToRemove sort: [ :a :b | a > b ]) do: [ :i |
-		listWithVersion removeAt: i ].
+	(indicesToRemove sort: [ :a :b | a > b ]) do: [ :i | listWithVersion removeAt: i ].
 
 	"This dependency conflict can be resolved normally"
 	^ listWithVersion sort: [ :a :b | self compare: a key to: b key ]
@@ -79,30 +77,24 @@ NexusSemanticVersioningDependencyConflictResolver >> compare: leftVersion to: ri
 	"major"
 	leftPart := leftVersion first.
 	rightPart := rightVersion first.
-	(leftPart isCharacter not and: [ rightPart isCharacter ]) ifTrue: [
-		^ false ].
-	(leftPart isCharacter and: [ rightPart isCharacter not ]) ifTrue: [
-		^ true ].
+	(leftPart isCharacter not and: [ rightPart isCharacter ]) ifTrue: [ ^ false ].
+	(leftPart isCharacter and: [ rightPart isCharacter not ]) ifTrue: [ ^ true ].
 	leftVersion first > rightVersion first ifTrue: [ ^ false ].
 	leftVersion first < rightVersion first ifTrue: [ ^ true ].
 
 	"minor"
 	leftPart := leftVersion second.
 	rightPart := rightVersion second.
-	(leftPart isCharacter not and: [ rightPart isCharacter ]) ifTrue: [
-		^ false ].
-	(leftPart isCharacter and: [ rightPart isCharacter not ]) ifTrue: [
-		^ true ].
+	(leftPart isCharacter not and: [ rightPart isCharacter ]) ifTrue: [ ^ false ].
+	(leftPart isCharacter and: [ rightPart isCharacter not ]) ifTrue: [ ^ true ].
 	leftPart > rightPart ifTrue: [ ^ false ].
 	leftPart < rightPart ifTrue: [ ^ true ].
 
 	"patch"
 	leftPart := leftVersion third.
 	rightPart := rightVersion third.
-	(leftPart isCharacter not and: [ rightPart isCharacter ]) ifTrue: [
-		^ false ].
-	(leftPart isCharacter and: [ rightPart isCharacter not ]) ifTrue: [
-		^ true ].
+	(leftPart isCharacter not and: [ rightPart isCharacter ]) ifTrue: [ ^ false ].
+	(leftPart isCharacter and: [ rightPart isCharacter not ]) ifTrue: [ ^ true ].
 	leftPart > rightPart ifTrue: [ ^ false ].
 	leftPart < rightPart ifTrue: [ ^ true ].
 
@@ -181,12 +173,10 @@ NexusSemanticVersioningDependencyConflictResolver >> parseVersionNumberFrom: aSt
 	"Read a numeric version component without requiring the following character to be valid Smalltalk number syntax."
 
 	| number |
-	(aStream atEnd or: [ aStream peek isDigit not ]) ifTrue: [
-		^ absentBlock value ].
+	(aStream atEnd or: [ aStream peek isDigit not ]) ifTrue: [ ^ absentBlock value ].
 
 	number := 0.
-	[ aStream atEnd not and: [ aStream peek isDigit ] ] whileTrue: [
-		number := number * 10 + aStream next digitValue ].
+	[ aStream atEnd not and: [ aStream peek isDigit ] ] whileTrue: [ number := number * 10 + aStream next digitValue ].
 
 	^ number
 ]
@@ -194,11 +184,10 @@ NexusSemanticVersioningDependencyConflictResolver >> parseVersionNumberFrom: aSt
 { #category : 'resolving' }
 NexusSemanticVersioningDependencyConflictResolver >> resolveConflictBetween: descriptors [
 
-	^ (self checkAndSortByVersion: descriptors) ifNotNil: [
-		  :listWithVersion |
-		  (listWithVersion at: (useLatest
-				    ifTrue: [ listWithVersion size ]
-				    ifFalse: [ 1 ])) value ]
+	^ (self checkAndSortByVersion: descriptors) ifNotNil: [ :listWithVersion |
+			  (listWithVersion at: (useLatest
+					    ifTrue: [ listWithVersion size ]
+					    ifFalse: [ 1 ])) value ]
 ]
 
 { #category : 'resolving' }
@@ -209,12 +198,11 @@ NexusSemanticVersioningDependencyConflictResolver >> resolveConflicts: conflicts
 	remaining := Dictionary new.
 
 	conflicts keysAndValuesDo: [ :groupAndName :descriptors |
-		(self resolveConflictBetween: descriptors)
-			ifNotNil: [ :chosen | dependencies at: groupAndName put: chosen ]
-			ifNil: [ remaining at: groupAndName put: descriptors ] ].
+			(self resolveConflictBetween: descriptors)
+				ifNotNil: [ :chosen | dependencies at: groupAndName put: chosen ]
+				ifNil: [ remaining at: groupAndName put: descriptors ] ].
 
-	remaining ifNotEmpty: [
-		self resolveRemainingConflicts: remaining on: dependencies ]
+	remaining ifNotEmpty: [ self resolveRemainingConflicts: remaining on: dependencies ]
 ]
 
 { #category : 'configuring' }

--- a/src/MooseNexus/NexusVersionLockingDependencyConflictResolver.class.st
+++ b/src/MooseNexus/NexusVersionLockingDependencyConflictResolver.class.st
@@ -53,16 +53,14 @@ NexusVersionLockingDependencyConflictResolver >> resolveConflicts: conflicts on:
 	remaining := Dictionary new.
 
 	conflicts keysAndValuesDo: [ :groupAndName :descriptors |
-		self locks
-			at: groupAndName
-			ifPresent: [ :version |
-				descriptors
-					detect: [ :descriptor | version = (descriptor at: #version) ]
-					ifFound: [ :descriptor |
-					dependencies at: groupAndName put: descriptor ]
-					ifNone: [ remaining at: groupAndName put: descriptors ] ]
-			ifAbsent: [ remaining at: groupAndName put: descriptors ] ].
+			self locks
+				at: groupAndName
+				ifPresent: [ :version |
+						descriptors
+							detect: [ :descriptor | version = (descriptor at: #version) ]
+							ifFound: [ :descriptor | dependencies at: groupAndName put: descriptor ]
+							ifNone: [ remaining at: groupAndName put: descriptors ] ]
+				ifAbsent: [ remaining at: groupAndName put: descriptors ] ].
 
-	remaining ifNotEmpty: [
-		self resolveRemainingConflicts: remaining on: dependencies ]
+	remaining ifNotEmpty: [ self resolveRemainingConflicts: remaining on: dependencies ]
 ]

--- a/src/MooseNexus/NexusVerveineJRunner.class.st
+++ b/src/MooseNexus/NexusVerveineJRunner.class.st
@@ -68,9 +68,7 @@ NexusVerveineJRunner >> anchor: aSymbol [
 	| expected |
 	expected := #( none entity default assoc ).
 	(expected includes: aSymbol) ifFalse: [
-		Error signal:
-			'Invalid anchor argument `' , aSymbol , '`, expects one of: '
-			, expected asCommaString ].
+		Error signal: 'Invalid anchor argument `' , aSymbol , '`, expects one of: ' , expected asCommaString ].
 	anchor := aSymbol
 ]
 
@@ -99,9 +97,7 @@ NexusVerveineJRunner >> format: aSymbol [
 	| expected |
 	expected := #( json mse ).
 	(expected includes: aSymbol) ifFalse: [
-		Error signal:
-			'Invalid format argument `' , aSymbol , '`, expects one of: '
-			, expected asCommaString ].
+		Error signal: 'Invalid format argument `' , aSymbol , '`, expects one of: ' , expected asCommaString ].
 	format := aSymbol
 ]
 
@@ -136,14 +132,12 @@ NexusVerveineJRunner >> jvmArgs: aString [
 NexusVerveineJRunner >> printOptionsOn: stream [
 
 	self jvmArgs ifNotNil: [ :args | stream << args << ' ' ].
-	stream << '-o ' << self class outputFilename << '.' << self format
-	<< ' -format ' << self format.
+	stream << '-o ' << self class outputFilename << '.' << self format << ' -format ' << self format.
 	self allLocals ifTrue: [ stream << ' -alllocals' ].
 	self anchor ifNotNil: [ :a | stream << ' -anchor ' << a ].
 	self javaVersion ifNotNil: [ :v | stream << ' -' << v ].
 	self summary ifTrue: [ stream << ' -summary' ].
-	self excludePaths ifNotEmpty: [ :paths |
-		paths do: [ :path | stream << ' -excludepath ' << path ] ]
+	self excludePaths ifNotEmpty: [ :paths | paths do: [ :path | stream << ' -excludepath ' << path ] ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
## Summary
- introduce `NexusProjectCoordinates` as the value object for project identity
- prevent changing project coordinates after a project has been recorded in a repository
- add repository APIs that accept coordinates before recording/importing
- update README usage to use the explicit coordinates import API
- add focused identity tests for coordinates and recorded projects

Closes #10

## Tests
- MooseNexus-Tests: 38 passed