### PR TITLE
Fail on missing managed project versions

### DIFF
--- a/src/MooseNexus-Tests/MooseNexusProjectVersionPolicyTest.class.st
+++ b/src/MooseNexus-Tests/MooseNexusProjectVersionPolicyTest.class.st
@@ -1,0 +1,65 @@
+Class {
+	#name : 'MooseNexusProjectVersionPolicyTest',
+	#superclass : 'TestCase',
+	#category : 'MooseNexus-Tests',
+	#package : 'MooseNexus-Tests'
+}
+
+{ #category : 'helpers' }
+MooseNexusProjectVersionPolicyTest >> projectWithVersion: version [
+
+	| project |
+	project := MooseNexusMavenProject new.
+	project projects: (Dictionary with: 'com.example' -> (Dictionary with: 'demo' -> (Dictionary with: #version -> version))).
+	^ project
+]
+
+{ #category : 'helpers' }
+MooseNexusProjectVersionPolicyTest >> projectWithoutVersion [
+
+	| project |
+	project := MooseNexusMavenProject new.
+	project projects: (Dictionary with: 'com.example' -> (Dictionary with: 'demo' -> Dictionary new)).
+	^ project
+]
+
+{ #category : 'tests' }
+MooseNexusProjectVersionPolicyTest >> testDetermineVersionAnswersDeclaredVersion [
+
+	self assert: (self projectWithVersion: '1.0.0') determineVersion equals: '1.0.0'
+]
+
+{ #category : 'tests' }
+MooseNexusProjectVersionPolicyTest >> testDetermineVersionAnswersLiteralUnspecifiedVersion [
+
+	self assert: (self projectWithVersion: 'unspecified') determineVersion equals: 'unspecified'
+]
+
+{ #category : 'tests' }
+MooseNexusProjectVersionPolicyTest >> testDetermineVersionFailsWhenVersionIsEmpty [
+
+	self should: [ (self projectWithVersion: '') determineVersion ] raise: Error
+]
+
+{ #category : 'tests' }
+MooseNexusProjectVersionPolicyTest >> testDetermineVersionFailsWhenVersionIsMissing [
+
+	self should: [ self projectWithoutVersion determineVersion ] raise: Error
+]
+
+{ #category : 'tests' }
+MooseNexusProjectVersionPolicyTest >> testGradleImporterRejectsUnspecifiedProjectVersion [
+
+	| importer |
+	importer := MooseNexusGradleProjectImporter new.
+	importer project: MooseNexusGradleProject new.
+
+	self
+		should: [
+				importer parse: 'header
+> Task :mooseNexusListDependencies
+-com.example:demo:unspecified
+.
+' ]
+		raise: Error
+]

--- a/src/MooseNexus/MooseNexusGradleProjectImporter.class.st
+++ b/src/MooseNexus/MooseNexusGradleProjectImporter.class.st
@@ -141,18 +141,18 @@ MooseNexusGradleProjectImporter >> newProject [
 
 { #category : 'parsing' }
 MooseNexusGradleProjectImporter >> parse: raw [
-	"Parses the result of the command listing the dependencies.
-	Resolves each dependency to obtain the path to its local location.
-	The result of the command is formatted as follows for each project:
--group:name:version
-directory
-(group:name:type:version:scope:path)*"
+	"Parses result command listing dependencies.
+	Resolves dependency obtain path local location.
+	The result command formatted project:
+	-group:name:version
+	directory
+	(group:name:type:version:scope:path)*"
 
 	| lines line index |
 	lines := raw lines.
 	index := 2.
 
-	[ "project info starts at third line at the earliest, after the line '> Task ...'"
+	[ "project info starts third line earliest, after line '> Task ...'"
 	(line := lines at: (index := index + 1)) isNotEmpty and: [ line first == $- ] ] whileFalse.
 
 	[ (line := lines at: index) isNotEmpty ] whileTrue: [
@@ -161,26 +161,25 @@ directory
 			descriptor := $: split: line allButFirst.
 			group := descriptor first ifEmpty: [ 'unknown' ].
 			name := descriptor second.
-			version := descriptor third.
+			version := self validateProjectVersion: descriptor third.
 
-			"register the project with its version; project name is unique so this never overwrites"
+			"register project version; project name unique never overwrites"
 			descriptor := Dictionary with: #version -> version.
 			project projects at: group at: name put: descriptor.
 
-			"read project location, relative to the directory"
+			"read project location, relative directory"
 			descriptor at: #path put: (lines at: (index := index + 1)).
 
 			"read dependencies per scope"
 			dependencies := Dictionary new.
-			[ (line := lines at: (index := index + 1)) isEmpty or: [ line first == $- ] ] whileFalse: [ "resolve the descriptor: 'group:name:type:version:scope:path'"
+			[ (line := lines at: (index := index + 1)) isEmpty or: [ line first == $- ] ] whileFalse: [ "resolve descriptor: 'group:name:type:version:scope:path'"
 					| mapping |
 					mapping := self resolve: line.
 					dependencies
 						at: mapping key
 						ifPresent: [ :descriptors | descriptors add: mapping value ]
 						ifAbsentPut: [ OrderedCollection with: mapping value ] ].
-
-			"the current project has been fully parsed, save the dependencies as arrays for JSON compatibility"
+			"the current project been fully parsed, save dependencies arrays JSON compatibility"
 			descriptor at: #dependencies put: (dependencies collect: #asArray) ]
 ]
 
@@ -204,6 +203,14 @@ MooseNexusGradleProjectImporter >> read [
 		  "execute the task we inserted and return the raw terminal output"
 		  LibC resultOfCommand: 'cd "' , directory pathString , '" && ' , gradleCmd , ' ' , self class taskName ] ensure: [ "restore the original build file"
 		  (File named: buildFile fullName) writeStreamDo: [ :ws | ws truncate: originalSize ] ]
+]
+
+{ #category : 'validating' }
+MooseNexusGradleProjectImporter >> validateProjectVersion: version [
+
+	version = 'unspecified' ifTrue: [
+		Error signal: 'Cannot infer MooseNexus project version from Gradle unspecified project version' ].
+	^ version
 ]
 
 { #category : 'accessing' }

--- a/src/MooseNexus/MooseNexusGradleProjectImporter.class.st
+++ b/src/MooseNexus/MooseNexusGradleProjectImporter.class.st
@@ -141,9 +141,9 @@ MooseNexusGradleProjectImporter >> newProject [
 
 { #category : 'parsing' }
 MooseNexusGradleProjectImporter >> parse: raw [
-	"Parses result command listing dependencies.
-	Resolves dependency obtain path local location.
-	The result command formatted project:
+	"Parses the result of the command listing the dependencies.
+	Resolves each dependency to obtain the path to its local location.
+	The result of the command is formatted as follows for each project:
 	-group:name:version
 	directory
 	(group:name:type:version:scope:path)*"
@@ -152,7 +152,7 @@ MooseNexusGradleProjectImporter >> parse: raw [
 	lines := raw lines.
 	index := 2.
 
-	[ "project info starts third line earliest, after line '> Task ...'"
+	[ "project info starts at the third line at the earliest, after the line '> Task ...'"
 	(line := lines at: (index := index + 1)) isNotEmpty and: [ line first == $- ] ] whileFalse.
 
 	[ (line := lines at: index) isNotEmpty ] whileTrue: [
@@ -163,23 +163,23 @@ MooseNexusGradleProjectImporter >> parse: raw [
 			name := descriptor second.
 			version := self validateProjectVersion: descriptor third.
 
-			"register project version; project name unique never overwrites"
+			"register the project with its version; project name is unique so this never overwrites"
 			descriptor := Dictionary with: #version -> version.
 			project projects at: group at: name put: descriptor.
 
-			"read project location, relative directory"
+			"read the project location, relative to the directory"
 			descriptor at: #path put: (lines at: (index := index + 1)).
 
 			"read dependencies per scope"
 			dependencies := Dictionary new.
-			[ (line := lines at: (index := index + 1)) isEmpty or: [ line first == $- ] ] whileFalse: [ "resolve descriptor: 'group:name:type:version:scope:path'"
+			[ (line := lines at: (index := index + 1)) isEmpty or: [ line first == $- ] ] whileFalse: [ "resolve the descriptor: 'group:name:type:version:scope:path'"
 					| mapping |
 					mapping := self resolve: line.
 					dependencies
 						at: mapping key
 						ifPresent: [ :descriptors | descriptors add: mapping value ]
 						ifAbsentPut: [ OrderedCollection with: mapping value ] ].
-			"the current project been fully parsed, save dependencies arrays JSON compatibility"
+			"the current project has been fully parsed, save the dependencies as arrays for JSON compatibility"
 			descriptor at: #dependencies put: (dependencies collect: #asArray) ]
 ]
 

--- a/src/MooseNexus/MooseNexusManagedProject.class.st
+++ b/src/MooseNexus/MooseNexusManagedProject.class.st
@@ -103,11 +103,13 @@ MooseNexusManagedProject >> determineVersion [
 	| theVersion |
 	(projects isNotEmpty and: [ projects anyOne isNotEmpty ]) ifFalse: [
 		Error signal: 'Cannot determine version because there are no managed projects' ].
-	"verify all managed projects declare the same version"
-	theVersion := projects anyOne anyOne at: #version.
+	"verify all managed projects declare same version"
+	theVersion := self validateProjectVersion: (projects anyOne anyOne at: #version ifAbsent: [ nil ]).
 	projects do: [ :projectGroup |
 			projectGroup do: [ :descriptor |
-					(descriptor at: #version) = theVersion ifFalse: [
+					| descriptorVersion |
+					descriptorVersion := self validateProjectVersion: (descriptor at: #version ifAbsent: [ nil ]).
+					descriptorVersion = theVersion ifFalse: [
 						Error signal: 'Can only determine version if all managed projects declare the same one' ] ] ].
 	^ theVersion
 ]
@@ -174,4 +176,12 @@ MooseNexusManagedProject >> properties [
 	^ super properties
 		  add: #projects -> self projects;
 		  yourself
+]
+
+{ #category : 'validating' }
+MooseNexusManagedProject >> validateProjectVersion: aString [
+
+	(aString isNil or: [ aString isEmpty ]) ifTrue: [
+		Error signal: 'Cannot determine version because a managed project does not declare one' ].
+	^ aString
 ]


### PR DESCRIPTION
## Summary
- make managed project version inference fail when a project version is missing or empty
- handle Gradle-specific `unspecified` project versions at the Gradle importer boundary
- keep literal `unspecified` as a possible MooseNexus managed-project version outside Gradle inference
- add focused regression tests for the default missing-version policy and Gradle `unspecified` handling

Related to #9

## Tests
- MooseNexus-Tests: 43 passed