### PR TITLE
Create repository layout before recording projects

### DIFF
--- a/src/MooseNexus-Tests/MooseNexusProjectIdentityTest.class.st
+++ b/src/MooseNexus-Tests/MooseNexusProjectIdentityTest.class.st
@@ -72,6 +72,25 @@ MooseNexusProjectIdentityTest >> testRecordedProjectRejectsCoordinateChanges [
 ]
 
 { #category : 'tests' }
+MooseNexusProjectIdentityTest >> testRepositoryCreatesLayoutBeforeRecordingProject [
+
+	| project coordinates projectDirectory |
+	project := MooseNexusTestProject new.
+	coordinates := MooseNexusProjectCoordinates group: 'com.example' name: 'demo' version: '1.0.0'.
+	projectDirectory := repository directory / 'repository' / 'com.example' / 'demo' / '1.0.0'.
+
+	self deny: repository directory exists.
+	repository recordProject: project coordinates: coordinates fromDirectory: sourceDirectory pathString.
+
+	self assert: projectDirectory exists.
+	self assert: (projectDirectory / 'sources') exists.
+	self assert: (projectDirectory / 'sources' / 'project') exists.
+	self assert: (projectDirectory / 'sources' / 'project' / 'README.txt') exists.
+	self assert: (projectDirectory / 'properties.json') exists.
+	self assert: (projectDirectory / 'models.json') exists
+]
+
+{ #category : 'tests' }
 MooseNexusProjectIdentityTest >> testRepositoryRecordWithCoordinatesSetsIdentityBeforeRecording [
 
 	| project coordinates recordedProject |

--- a/src/MooseNexus/MooseNexusRepository.class.st
+++ b/src/MooseNexus/MooseNexusRepository.class.st
@@ -111,6 +111,19 @@ MooseNexusRepository >> importGroup: group name: name version: version fromDirec
 	^ self importCoordinates: (MooseNexusProjectCoordinates group: group name: name version: version) fromDirectory: pathString
 ]
 
+{ #category : 'adding' }
+MooseNexusRepository >> prepareDirectoryOf: project [
+	"Create the repository layout needed before copying sources or writing metadata."
+
+	| projectDirectory |
+	projectDirectory := self resolveDirectoryOf: project.
+	projectDirectory ifExists: [
+			Warning signal: 'This project already exists in given repository, proceed to overwrite it'.
+			projectDirectory deleteAll ].
+	(projectDirectory / 'sources' / 'project') ensureCreateDirectory.
+	^ projectDirectory
+]
+
 { #category : 'printing' }
 MooseNexusRepository >> printOn: stream [
 
@@ -171,13 +184,11 @@ MooseNexusRepository >> recordProject: project fromDirectory: pathString [
 	"Add project to the repository, copying sources from the given directory."
 
 	| projectDirectory |
-	(projectDirectory := self resolveDirectoryOf: project) ifExists: [
-			Warning signal: 'This project already exists in given repository, proceed to overwrite it'.
-			projectDirectory deleteAll ].
+	projectDirectory := self prepareDirectoryOf: project.
 	project directory: (projectDirectory relativeTo: FileLocator home) pathString.
 
 	"copy project directory to repository"
-	pathString asFileReference copyAllTo: (projectDirectory / 'sources/project') ensureCreateDirectory.
+	pathString asFileReference copyAllTo: projectDirectory / 'sources' / 'project'.
 
 	"write properties file useful for Nexus"
 	(projectDirectory / 'properties.json') ensureCreateFile writeStreamDo: [ :stream | project writePropertiesOn: stream ].


### PR DESCRIPTION
## Summary
- create the MooseNexus project repository layout before copying source files or writing metadata
- keep overwrite behavior in one preparation method
- add a regression test that records into a missing repository root and checks the expected layout

Closes #6

## Tests
- MooseNexus-Tests: 44 passed